### PR TITLE
Add common group

### DIFF
--- a/ansible/inventories/local_development
+++ b/ansible/inventories/local_development
@@ -1,11 +1,13 @@
 
+[common:children]
+env_local_development
+
 [env_local_development:children]
 db
 shell
 web
 
-
-# In a development environement, or simple deployment the database is collocated
+# In a development environement, or simple deployment collocate the database
 # with the web server
 [db]
 dev_web     ansible_connection=local

--- a/ansible/inventories/local_testing
+++ b/ansible/inventories/local_testing
@@ -1,4 +1,7 @@
 
+[common:children]
+env_local_testing
+
 [env_local_testing:children]
 db
 shell

--- a/ansible/inventories/remote_testing
+++ b/ansible/inventories/remote_testing
@@ -3,6 +3,9 @@
 # please first change these values to match the results from Terraform
 # or your own manual configuration of remote servers
 
+[common:children]
+env_remote_testing
+
 [env_remote_testing:children]
 db
 shell

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -11,10 +11,8 @@
     - network
     - dependency
 
-# Developement settings are the only environment where the platform should
-# be loaded in directly without being cloned from a specific source and
-# branch
-- include_vars: group_vars/common.yml
+# Local development environements are the only place the platform should
+# be loaded in directly without being cloned from a specific source and branch
 - include: clone_repo.yml
   when: "'env_local_development' not in group_names"
   tags:

--- a/ansible/roles/pico-shell/tasks/main.yml
+++ b/ansible/roles/pico-shell/tasks/main.yml
@@ -1,10 +1,6 @@
 ---
 # Playbook that installs and configures picoCTF-shell servers
 
-- include_vars:  group_vars/common.yml
-  tags:
-    - always
-
 # Need to load passwords from the vault for remote environments
 - include_vars: group_vars/vault_remote_testing.yml
   when: "'env_remote_testing' in group_names" 

--- a/ansible/roles/pico-web/tasks/main.yml
+++ b/ansible/roles/pico-web/tasks/main.yml
@@ -1,10 +1,6 @@
 ---
 # Playbook that installs and configures picoCTF-web servers
 
-- include_vars:  group_vars/common.yml
-  tags:
-    - always
-
 # Need to load passwords from the vault for remote environments
 - include_vars: group_vars/vault_remote_testing.yml
   when: "'env_remote_testing' in group_names"


### PR DESCRIPTION
This pull adds a common group to the ansible inventory files which allows the subsequent plays to access the common variables without explicitly calling include.