### PR TITLE
Fix pam initial login so message shows

### DIFF
--- a/ansible/roles/pico-shell/tasks/shell_manager.yml
+++ b/ansible/roles/pico-shell/tasks/shell_manager.yml
@@ -48,6 +48,6 @@
 
 - name: Copy securebashrc to deployed location
   copy:
-    dest: "/opt/hacksports/extra/"
+    dest: "/opt/hacksports/config/"
     src:  "{{ securebashrc_src }}"
     remote_src: True 


### PR DESCRIPTION
- placed securebashrc where pam module expected it.
- this works, and matches the existing behavior of the picoCTF-platform,
  but could be made much more robust