### PR TITLE
Change remote_testing to use ansible_host for fqdn

### DIFF
--- a/ansible/group_vars/remote_testing/vars.yml
+++ b/ansible/group_vars/remote_testing/vars.yml
@@ -9,15 +9,11 @@ ansible_user: admin
 private_repo: True
 deploy_private_key_file: "deploy.picoCTF.private-repo.id_rsa"
 
-## Minimal Changes
-web_fqdn: "CHANGE_ME"
-shell_hostname: "CHANGE_ME"
-
 ##
 # Web settings (env specific)
 ##
+web_fqdn: "{{ ansible_host }}"
 nginx_server_name: "{{ web_fqdn }}"
-#[TODO] refactor based on "facts"
 web_address: "{{ web_fqdn }}"
 web_address_internal: "http://10.0.1.10"
 htpasswd_accounts: "{{ vault_htpasswd_accounts }}"
@@ -36,6 +32,7 @@ auto_start_competition: True
 ###
 # Shell Settings (env specific)
 ###
+shell_hostname: "{{ ansible_host }}"
 shell_name: Remote-Testing-Shell
 shell_host: "{{ shell_hostname }}"
 shell_user: "{{ ansible_user }}"

--- a/ansible/inventories/remote_testing
+++ b/ansible/inventories/remote_testing
@@ -1,8 +1,7 @@
 # Inventory to provision/administer a remote development environment
 
-# These are example IP addresses. In order to use this inventory
-# please first change these values to match the results from Terraform
-# or your own manual configuration of remote servers.
+# In order to use this inventory change these values to match the output
+# from Terraform or your own manual configuration of remote servers.
 
 [common:children]
 remote_testing
@@ -13,11 +12,11 @@ shell
 web
 
 [db]
-remote_testing_db      ansible_host=203.0.113.254   hostname=pico-aws-testing-db
+remote_testing_db      ansible_host=CHANGE_ME   hostname=pico-aws-testing-db
 
 [shell]
-remote_testing_shell   ansible_host=203.0.113.254   hostname=pico-aws-testing-shell
+remote_testing_shell   ansible_host=CHANGE_ME   hostname=pico-aws-testing-shell
 
 [web]
-remote_testing_web     ansible_host=203.0.113.254   hostname=pico-aws-testing-web
+remote_testing_web     ansible_host=CHANGE_ME   hostname=pico-aws-testing-web
 


### PR DESCRIPTION
- this ensures minimal changes are necessary for the test example that
  only uses IP addresses
