### PR TITLE
Remove db auth for the development environment.

### DIFF
--- a/ansible/group_vars/local_development/vars.yml
+++ b/ansible/group_vars/local_development/vars.yml
@@ -40,17 +40,7 @@ shell_admin_password_crypt: "$6$0GcSqMClzx$qEKEiL78VE/Xe0gzuGGuWyUqAlZMObkGnRYwH
 # Database settings (env specific)
 ##
 db_private_ip: 127.0.0.1
-picoAdmin_db_password:  "insecure-password"
-picoWeb_db_password:    "insecure-password"
-
-# [TODO] remove auth for development
-env_db_users:
-  - {
-    name: picoWeb,
-    password: "{{ picoWeb_db_password }}",
-    roles: readWrite,
-    database: "{{ picoCTF_db_name }}"
-  }
+mongodb_conf_auth: False
 
 ##
 # Problem Settings

--- a/ansible/roles/mongodb/tasks/main.yml
+++ b/ansible/roles/mongodb/tasks/main.yml
@@ -14,7 +14,10 @@
 
 - include: configure_mongo.yml
 
+# Default to running the database with authentication.  The development
+# environment is the only place `mongodb_conf_auth` should be false
 - include: configure_auth.yml
+  when: mongodb_conf_auth
 
 - name: Ensure mongodb is started
   service: 

--- a/ansible/roles/pico-web/templates/deploy_settings.py.j2
+++ b/ansible/roles/pico-web/templates/deploy_settings.py.j2
@@ -2,8 +2,10 @@
 MONGO_DB_NAME = "{{ picoCTF_db_name }}"
 MONGO_ADDR = "{{ db_private_ip }}"
 MONGO_PORT = "{{ mongodb_conf_port | default(27017)}}"
+{% if  mongodb_conf_auth %}
 MONGO_USER = "{{ mongodb_web_user | default("picoWeb") }}"
 MONGO_PW = "{{ picoWeb_db_password }}"
+{% endif %}
 
 SERVER_NAME = "{{ flask_app_server_name }}"
 SECRET_KEY = "{{ flask_app_secret_key | default("INSECURE_DEFAULT_CHANGE_ME") }}"


### PR DESCRIPTION
- This simplifies the development while not removing any security from
  the standard configuration.
- db auth defaults to on
