### PR TITLE
Dependency issue fix

### DIFF
--- a/ansible/roles/pico-shell/tasks/dependencies.yml
+++ b/ansible/roles/pico-shell/tasks/dependencies.yml
@@ -27,7 +27,7 @@
     - nginx           # used to serve shellinabox and challenge binaries
     - shellinabox
 
-    
+
 # Needed by templated challenge types
 - name: Install uwsgi and plugins for shell server
   apt:
@@ -52,3 +52,13 @@
 - name: Install requests
   pip:
     name: requests
+
+- name: Install python packaging
+  pip:
+    name: packaging
+    executable: pip3
+
+- name: Install python appdirs
+  pip:
+    name: appdirs
+    executable: pip3

--- a/ansible/roles/pico-web/tasks/dependencies.yml
+++ b/ansible/roles/pico-web/tasks/dependencies.yml
@@ -14,7 +14,17 @@
   with_items:
     - python3-pip
     - gunicorn
-    - jekyll 
+    - jekyll
     - nginx
     - libffi-dev
     - libssl-dev
+
+- name: Install python packaging
+  pip:
+    name: packaging
+    executable: pip3
+
+- name: Install python appdirs
+  pip:
+    name: appdirs
+    executable: pip3


### PR DESCRIPTION
Added additional dependencies, fixed pip3 errors when installing the shell and web manager from source.

Probably not the best way to add them in, but gets things working for problem dev meeting on 29 Jan.

Bug:
Install fails (on vm, using OSX, Vagrant, and Virtualbox) in the [shell](https://github.com/picoCTF/picoCTF/blob/master/ansible/roles/pico-shell/tasks/shell_manager.yml#L5) and [web](https://github.com/picoCTF/picoCTF/blob/master/ansible/roles/pico-web/tasks/picoCTF-webapp.yml#L12) VMs, missing packaging and appdirs. 