### PR TITLE
Update Python setuptools before installing packages

### DIFF
--- a/ansible/roles/pico-shell/tasks/shell_manager.yml
+++ b/ansible/roles/pico-shell/tasks/shell_manager.yml
@@ -1,6 +1,13 @@
 ---
 # Playbook that installs and configures the picoCTF shell_manager from sourrce
 
+# Fix "Invalid environment marker: platform_python_implementation != 'PyPy'"
+- name: Upgrade setuptools
+  pip:
+    name: "setuptools"
+    executable: pip3
+    extra_args: "--upgrade"
+
 # Source was cloned in main
 - name: Install picoCTF-shell-manager from source
   pip:
@@ -47,4 +54,3 @@
   copy:
     src:  "securebashrc"
     dest: "/opt/hacksports/config/securebashrc"
-

--- a/ansible/roles/pico-web/tasks/picoCTF-webapp.yml
+++ b/ansible/roles/pico-web/tasks/picoCTF-webapp.yml
@@ -8,6 +8,13 @@
     group: "{{ ansible_user }}"
     state: directory
 
+# Fix "Invalid environment marker: platform_python_implementation != 'PyPy'"
+- name: Upgrade setuptools
+  pip:
+    name: "setuptools"
+    executable: pip3
+    extra_args: "--upgrade"
+
 # Source was cloned in main
 - name: Install picoCTF-web api from source
   pip:


### PR DESCRIPTION
Before this commit, `vagrant up` will fail as of this writing due to:
```
[...]
Downloading/unpacking cryptography>=1.5 (from paramiko>=1.13.1,<3->spur->ctf-shell-manager==1.2.1)
  Running setup.py (path:/tmp/pip-build-6xfnjkte/cryptography/setup.py) egg_info for package cryptography
    error in cryptography setup command: Invalid environment marker: platform_python_implementation != 'PyPy'
[...]
```
