### PR TITLE
Add user extdata routes

### DIFF
--- a/picoCTF-web/api/routes/user.py
+++ b/picoCTF-web/api/routes/user.py
@@ -176,3 +176,26 @@ def shell_servers_hook():
         "protocol": server['protocol']
     } for server in api.shell_servers.get_servers()]
     return WebSuccess(data=servers)
+
+
+@blueprint.route('/extdata', methods=['GET'])
+@api_wrapper
+@require_login
+def get_extdata_hook():
+    """
+    Return user extdata, or empty JSON object if unset.
+    """
+    user = api.user.get_user(uid=None)
+    return WebSuccess(data=user['extdata'])
+
+
+@blueprint.route('/extdata', methods=['PUT'])
+@api_wrapper
+@check_csrf
+@require_login
+def update_extdata_hook():
+    """
+    Sets user extdata via HTTP form. Takes in any key-value pairs.
+    """
+    api.user.update_extdata(api.common.flat_multi(request.form))
+    return WebSuccess("Your Extdata has been successfully updated.")

--- a/picoCTF-web/api/user.py
+++ b/picoCTF-web/api/user.py
@@ -238,6 +238,7 @@ def create_user(username,
         'disabled': False,
         'country': country,
         'verified': not settings["email"]["email_verification"] or verified,
+        'extdata': {},
     }
 
     db.users.insert(user)
@@ -550,3 +551,18 @@ def disable_account_request(params, uid=None, check_current=False):
     disable_account(user['uid'])
 
     api.auth.logout()
+
+
+def update_extdata(params):
+    """
+    Update user extdata.
+    Assumes args are keys in params.
+
+    Args:
+        params:
+            (any)
+    """
+    user = get_user(uid=None)
+    db = api.common.get_conn()
+    params.pop('token', None)
+    db.users.update_one({'uid': user['uid']}, {'$set': {'extdata': params}})


### PR DESCRIPTION
Use to store arbitrary data per user, such as for pioCTF game persistence.