### PR TITLE
Replace deprecated module and methods

### DIFF
--- a/picoCTF-shell/hacksport/deploy.py
+++ b/picoCTF-shell/hacksport/deploy.py
@@ -90,7 +90,7 @@ from abc import ABCMeta
 from copy import copy, deepcopy
 from grp import getgrnam
 from hashlib import md5, sha1
-from imp import load_source
+from importlib.machinery import SourceFileLoader
 # These are below because of a cirucular import issue with problem.py and give_port
 # [TODO] cleanup
 from os.path import commonprefix, isdir, isfile, join
@@ -525,7 +525,8 @@ def generate_instance(problem_object,
     cwd = os.getcwd()
     os.chdir(copy_path)
 
-    challenge = load_source("challenge", join(copy_path, "challenge.py"))
+    challenge = SourceFileLoader("challenge",
+                                 join(copy_path, "challenge.py")).load_module()
 
     Problem = update_problem_class(challenge.Problem, problem_object, seed,
                                    username, deployment_directory)
@@ -797,8 +798,9 @@ def deploy_problems(args, config):
 
     if args.secret:
         deploy_config.deploy_secret = args.secret
-        logger.warn("Overriding deploy_secret with user supplied secret '%s'.",
-                    args.secret)
+        logger.warning(
+            "Overriding deploy_secret with user supplied secret '%s'.",
+            args.secret)
 
     problem_names = args.problem_paths
 
@@ -967,7 +969,7 @@ def undeploy_problems(args, config):
                     filter(lambda x: x in already_deployed[problem["name"]],
                            instance_list))
                 if len(instances) == 0:
-                    logger.warn(
+                    logger.warning(
                         "No deployed instances %s were found for problem '%s'.",
                         instance_list, problem["name"])
                 else:

--- a/picoCTF-web/api/achievement.py
+++ b/picoCTF-web/api/achievement.py
@@ -1,6 +1,6 @@
 """ Module for interacting with the achievements """
 
-import imp
+from importlib.machinery import SourceFileLoader
 from datetime import datetime
 from os.path import join
 
@@ -269,7 +269,7 @@ def get_processor(aid):
         path = get_achievement(aid=aid, show_disabled=True)["processor"]
         base_path = api.config.get_settings()["achievements"][
             "processor_base_path"]
-        return imp.load_source(path[:-3], join(base_path, path))
+        return SourceFileLoader(path[:-3], join(base_path, path)).load_module()
     except FileNotFoundError:
         raise InternalException("Achievement processor is offline.")
 

--- a/picoCTF-web/api/daemon_manager.py
+++ b/picoCTF-web/api/daemon_manager.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 import argparse
 import glob
-import imp
+from importlib.machinery import SourceFileLoader
 import time
 from os.path import basename, splitext
 
@@ -11,7 +11,7 @@ import api
 def load_modules(directory):
     files = glob.glob("{}/*.py".format(directory))
     return [
-        imp.load_source(splitext(basename(module))[0], module)
+        SourceFileLoader(splitext(basename(module))[0], module).load_module()
         for module in files
     ]
 


### PR DESCRIPTION
Replace `logger.warn()` with `logger.warning()`.
Per https://bugs.python.org/issue14551, replace `imp.load_source()`
with `importlib.machinery.SourceFileLoader.load_module()`