### PR TITLE
Update EOL MongoDB and Nodejs

### DIFF
--- a/ansible/roles/mongodb/defaults/main.yml
+++ b/ansible/roles/mongodb/defaults/main.yml
@@ -22,13 +22,12 @@ mongodb_user: mongodb
 mongodb_daemon_name: mongod
 
 mongodb_apt_keyserver: keyserver.ubuntu.com
-mongodb_apt_key_id: EA312927
-mongodb_repo: 'deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 multiverse'
+mongodb_apt_key_id: 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
+mongodb_repo: 'deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse'
 
 mongodb_conf_auth: true                                               # Run with security
 mongodb_conf_bind_ip: "0.0.0.0"                                       # IP addresses to listen on (Static)
 mongodb_conf_port: 27017                                              # Port number
-mongodb_conf_nohttpinterface: true                                    # Disable http interface
 mongodb_conf_journal: true                                            # Enable journaling
 mongodb_conf_logappend: true                                          # Append instead of over-writing
 mongodb_conf_logpath: /var/log/mongodb/{{ mongodb_daemon_name }}.log  # Log to file (not stdout)

--- a/ansible/roles/mongodb/templates/mongod.conf.j2
+++ b/ansible/roles/mongodb/templates/mongod.conf.j2
@@ -3,7 +3,6 @@
 auth = {{ mongodb_conf_auth|to_nice_json }}
 bind_ip = {{ mongodb_conf_bind_ip }}
 dbpath = {{ mongodb_conf_dbpath }}
-nohttpinterface = {{ mongodb_conf_nohttpinterface|to_nice_json }}
 journal = {{ mongodb_conf_journal|to_nice_json }}
 logappend = {{ mongodb_conf_logappend|to_nice_json }}
 logpath = {{ mongodb_conf_logpath }}

--- a/ansible/roles/pico-web/tasks/nodejs.yml
+++ b/ansible/roles/pico-web/tasks/nodejs.yml
@@ -9,8 +9,8 @@
   register: nodejs
 
 - name: Download nodejs 4.x setup script (LTS)
-  get_url: 
-    url: "https://deb.nodesource.com/setup_4.x"
+  get_url:
+    url: "https://deb.nodesource.com/setup_8.x"
     dest: "/tmp/node_setup.sh"
     mode: 0700
 
@@ -36,7 +36,7 @@
 
 # Extracted from picoCTF-platform/scripts/web_setup.sh
 - name: Install nodejs packages (globally)
-  npm: 
+  npm:
     name: "{{ item }}"
     global: yes
   with_items:

--- a/picoCTF-web/setup.py
+++ b/picoCTF-web/setup.py
@@ -81,7 +81,7 @@ setup(
         'gunicorn==19.8.1',
         'line_profiler==2.1.2',
         'py==1.5.3',
-        'pymongo==3.2.1',
+        'pymongo==3.7.0',
         'pytest==3.6.1',
         'spur==0.3.20',
         'voluptuous==0.11.1',


### PR DESCRIPTION
- Mongodb 3.2 to 3.6 (EOL TBD)
- Remove deprecated `nohttpinterface` config
- Nodejs 4.x to active LTS 8.x (EOL Dec 2019)
- Update pymongo pin to latest

Addresses #113 