### PR TITLE
Reinstate web username creation blacklist

### DIFF
--- a/picoCTF-web/api/config.py
+++ b/picoCTF-web/api/config.py
@@ -30,24 +30,91 @@ These are the default settings that will be loaded
 into the database if no settings are already loaded.
 """
 default_settings = {
-    "enable_teachers": True,
-    "enable_feedback": True,
+    "enable_teachers":
+    True,
+    "enable_feedback":
+    True,
 
     # TIME WINDOW
-    "start_time": datetime.datetime.utcnow(),
-    "end_time": datetime.datetime.utcnow(),
+    "start_time":
+    datetime.datetime.utcnow(),
+    "end_time":
+    datetime.datetime.utcnow(),
 
     # EMAIL WHITELIST
     "email_filter": [],
 
     # TEAMS
-    "max_team_size": 1,
+    "max_team_size":
+    1,
 
     # ACHIEVEMENTS
     "achievements": {
         "enable_achievements": True,
         "processor_base_path": "./achievements",
     },
+    "username_blacklist": [
+        "adm",
+        "admin",
+        "audio",
+        "backup",
+        "bin",
+        "cdrom",
+        "competitors",
+        "crontab",
+        "daemon",
+        "dialout",
+        "dip",
+        "disk",
+        "dnsmasq",
+        "fax",
+        "floppy",
+        "games",
+        "gnats",
+        "hacksports",
+        "input",
+        "irc",
+        "kmem",
+        "list",
+        "lp",
+        "lxd",
+        "mail",
+        "man",
+        "messagebus",
+        "mlocate",
+        "netdev",
+        "news",
+        "nobody",
+        "nogroup",
+        "operator",
+        "plugdev",
+        "pollinate",
+        "proxy",
+        "root",
+        "sasl",
+        "shadow",
+        "shellinabox",
+        "src",
+        "ssh",
+        "sshd",
+        "staff",
+        "sudo",
+        "sync",
+        "sys",
+        "syslog",
+        "tape",
+        "tty",
+        "ubuntu",
+        "users",
+        "utmp",
+        "uucp",
+        "uuidd",
+        "vagrant",
+        "vboxadd",
+        "vboxsf",
+        "video",
+        "voice",
+    ],
 
     # EMAIL (SMTP)
     "email": {

--- a/picoCTF-web/api/user.py
+++ b/picoCTF-web/api/user.py
@@ -24,6 +24,16 @@ def _check_username(username):
         [c in string.digits + string.ascii_lowercase for c in username.lower()])
 
 
+def check_blacklisted_usernames(username):
+    """
+    Verify that the username isn't present in the username blacklist.
+    """
+
+    settings = api.config.get_settings()
+    return username not in settings.get(
+        "username_blacklist", api.config.default_settings["username_blacklist"])
+
+
 def verify_email_in_whitelist(email, whitelist=None):
     """
     Verify that the email address passes the global whitelist if one exists.
@@ -71,7 +81,9 @@ user_schema = Schema(
               ("This username already exists.",
                [lambda name: safe_fail(get_user, name=name) is None]),
               ("This username conflicts with an existing team.",
-               [lambda name: safe_fail(api.team.get_team, name=name) is None])),
+               [lambda name: safe_fail(api.team.get_team, name=name) is None]),
+              ("This username is reserved. Please choose another one.",
+               [check_blacklisted_usernames])),
         Required('password'):
         check(("Passwords must be between 3 and 20 characters.",
                [str, Length(min=3, max=20)])),


### PR DESCRIPTION
To address issue #49: bringing back `picoCTF-web-deprecated` PR#57 username
blacklist with default ubuntu 16.04 alphanumeric user/group names, as well as
ctf names `hacksports` and `shellinabox`. Note that this measure is no longer
a matter of security against privilege escalation via ubuntu system groups
such as `sudu` (see #49 discussion), but rather to prevent the creation of
crippled web accounts that are unable to login to the shell. Does not attempt
to prevent collisions with problem instance names as ascii alphanumeric limitation
already exists for web account creation.