### PR TITLE
Fix gunicorn and ctf-daemon services starts

### DIFF
--- a/ansible/roles/pico-web/tasks/gunicorn.yml
+++ b/ansible/roles/pico-web/tasks/gunicorn.yml
@@ -30,12 +30,8 @@
 - name: Get systemd to pickup gunicorn.service
   command: systemctl daemon-reload
 
-- name: Ensure gunicorn is enabled
+- name: Ensure gunicorn is enabled and restart
   service:
-    name: gunicorn
-    enabled: yes
-
-- name: Ensure gunicorn is restarted
-  service:
-    name: gunicorn
+    name: gunicorn.service
     state: restarted
+    enabled: yes

--- a/ansible/roles/pico-web/templates/ctf-daemon.service.j2
+++ b/ansible/roles/pico-web/templates/ctf-daemon.service.j2
@@ -1,10 +1,11 @@
 [Unit]
 Description= ctf daemon runner
+After=network.target vboxadd-service.service
 
 [Service]
 Type=simple
 Environment="APP_SETTINGS_FILE={{ web_config_dir }}/deploy_settings.py"
-Environment="PATH={{ virtualenv_dir }}"
+ExecStartPre=/bin/sleep 15
 ExecStart={{ virtualenv_dir }}/bin/daemon_manager -d {{ daemon_src_dir }} cache_stats share_instances
 RestartSec="5min"
 Restart=always

--- a/ansible/roles/pico-web/templates/gunicorn.service.j2
+++ b/ansible/roles/pico-web/templates/gunicorn.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=gunicorn daemon
 Requires=gunicorn.socket
-After=network.target vboxadd-service
+After=network.target vboxadd-service.service
 
 [Service]
 Environment="APP_SETTINGS_FILE={{ web_config_dir }}/deploy_settings.py"

--- a/ansible/roles/pico-web/templates/gunicorn.service.j2
+++ b/ansible/roles/pico-web/templates/gunicorn.service.j2
@@ -1,15 +1,15 @@
 [Unit]
 Description=gunicorn daemon
 Requires=gunicorn.socket
-After=network.target
+After=network.target vboxadd-service
 
 [Service]
 Environment="APP_SETTINGS_FILE={{ web_config_dir }}/deploy_settings.py"
-Environment="PATH={{ virtualenv_dir }}"
 PIDFile=/run/gunicorn/pid
 User= {{ gunicorn_user }}
 Group= {{ gunicorn_group }}
 WorkingDirectory= {{ gunicorn_working_dir }}
+ExecStartPre=/bin/sleep 15
 ExecStart={{ virtualenv_dir }}/bin/gunicorn --pid /run/gunicorn/pid -b {{ gunicorn_listen_on }} -w {{ num_workers }} 'api.app:config_app()'
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID


### PR DESCRIPTION
Allows `vagrant up web` to properly start VM even after ungraceful shutdown,
re-provisioning is no longer required.

- Fix ansible task failure of enabling gunicorn service, likely due to
ambiguity of `gunicorn` to `gunicorn.service` vs `gunicorn.socket`.
- Add 15s sleep and `vboxadd-service` to `After` directive in `gunicorn` and
`ctf-daemon` service configs to ensure that they start after vbox shared
directories have had time to mount. Note that `vboxadd-service` is not
*Required*.