### PR TITLE
Fixed undeploy.

### DIFF
--- a/picoCTF-shell/hacksport/deploy.py
+++ b/picoCTF-shell/hacksport/deploy.py
@@ -919,7 +919,7 @@ def deploy_problems(args, config):
 
 def remove_instances(path, instance_list):
     """ Remove all files under deployment directory and metdata for a given list of instances """
-
+    path = path.lower().replace(" ", "-")
     problem_instances = get_all_problem_instances(path)
     deployment_json_dir = join(DEPLOYED_ROOT, path)
 
@@ -970,14 +970,13 @@ def undeploy_problems(args, config):
                     raise FatalException
         problem_names = bundle_problems
 
-    # before deploying problems, load in already_deployed instances
+    # before undeploying problems, load in already_deployed instances
     already_deployed = {}
     for path, problem in get_all_problems().items():
         already_deployed[problem["name"]] = []
         for instance in get_all_problem_instances(path):
             already_deployed[problem["name"]].append(
                 instance["instance_number"])
-
     lock_file = join(HACKSPORTS_ROOT, "deploy.lock")
     if os.path.isfile(lock_file):
         logger.error(


### PR DESCRIPTION
The issue was the name of the problem was being used for the path.
Path that was past upper case with spaces, the name of the problem.
get_all_problem_instances() requires the path to be lowercase with '-' rather then spaces.
SQL Injection 1 -> sql-injection-1