### PR TITLE
Added email to pico-web

### DIFF
--- a/ansible/roles/pico-web/tasks/picoCTF-webapp.yml
+++ b/ansible/roles/pico-web/tasks/picoCTF-webapp.yml
@@ -44,3 +44,8 @@
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
   no_log: True
+
+- name: Install sendgrid-python 
+  pip:
+    name: sendgrid
+    virtualenv: "{{ virtualenv_dir }}"


### PR DESCRIPTION
fixing Issue #21 
This uses SendGrid instead of Mailgun, but both are free mail services

A SendGrid API key needs to be manually added to picoCTF-web/api/email.py in line 15 prior to provisioning, because GitGuardian is unhappy when API keys are published on GitHub. I attempted to add it to the environment variables using Ansible, but was unsuccessful; this works well enough for now to fix the password reset Issue #131 

api.config.competition_name and api.config.competition_urls are incorrectly configured and will cause request_password_reset to fail, so these have also been commented out for now. 