### PR TITLE
Fixed email

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,9 @@ If you are looking to run your own CTF competition, you should:
    ansible.
 2. You can reskin the look and feel of the site by editing the
    [picoCTF-web/web](picoCTF-web/web) javascript and HTML code.
-3. You should start writing your own problems, loading them into the shell
+3. To enable password reset emails, log in using the site administrator 
+   account and configure Email under Management > Configuration. 
+4. You should start writing your own problems, loading them into the shell
    server, and syncing the web server problem set with the shell server via the
    `/admin` URL endpoint.
 

--- a/picoCTF-web/api/api_manager.py
+++ b/picoCTF-web/api/api_manager.py
@@ -223,8 +223,9 @@ def load_problems(args):
 
 
 def main():
+    settings = api.config.get_settings()
     parser = argparse.ArgumentParser(
-        description="{} problem manager".format(api.config.competition_name))
+        description="{} problem manager".format(settings["competition_name"]))
     debug_level = parser.add_mutually_exclusive_group()
     debug_level.add_argument(
         '-v',

--- a/picoCTF-web/api/config.py
+++ b/picoCTF-web/api/config.py
@@ -187,6 +187,3 @@ def change_settings(changes):
     check_keys(settings, changes)
 
     db.settings.update({"_id": settings["_id"]}, {"$set": changes})
-
-    # Update Flask app settings (necessary for email to work)
-    api.app.config_app()

--- a/picoCTF-web/api/config.py
+++ b/picoCTF-web/api/config.py
@@ -47,6 +47,10 @@ default_settings = {
     "end_time":
     datetime.datetime.utcnow(),
 
+    # COMPETITION INFORMATION
+    "competition_name": "",
+    "competition_url": "",
+
     # EMAIL WHITELIST
     "email_filter": [],
 

--- a/picoCTF-web/api/config.py
+++ b/picoCTF-web/api/config.py
@@ -25,6 +25,12 @@ class EST(datetime.tzinfo):
         return datetime.timedelta(0)
 
 
+# Competition Information Placeholder
+competition_name = ""
+competition_urls = [
+    "",
+]
+
 """ CTF Settings
 These are the default settings that will be loaded
 into the database if no settings are already loaded.
@@ -181,3 +187,6 @@ def change_settings(changes):
     check_keys(settings, changes)
 
     db.settings.update({"_id": settings["_id"]}, {"$set": changes})
+
+    # Update Flask app settings (necessary for email to work)
+    api.app.config_app()

--- a/picoCTF-web/api/email.py
+++ b/picoCTF-web/api/email.py
@@ -73,11 +73,13 @@ def request_password_reset(username):
 
     token_value = api.token.set_token({"uid": user['uid']}, "password_reset")
 
+    settings = api.config.get_settings()
+
     body = """We recently received a request to reset the password for the following {0} account:\n\n\t{2}\n\nOur records show that this is the email address used to register the above account.  If you did not request to reset the password for the above account then you need not take any further steps.  If you did request the password reset please follow the link below to set your new password. \n\n {1}/reset#{3} \n\n Best of luck! \n The {0} Team""".format(
-        api.config.competition_name, api.config.competition_urls[0], username,
+        settings["competition_name"], settings["competition_url"], username,
         token_value)
 
-    subject = "{} Password Reset".format(api.config.competition_name)
+    subject = "{} Password Reset".format(settings["competition_name"])
 
     message = Message(body=body, recipients=[user['email']], subject=subject)
     mail.send(message)
@@ -123,7 +125,7 @@ def send_user_verification_email(username):
 
     # Is there a better way to do this without dragging url_for + app_context into it?
     verification_link = "{}/api/user/verify?uid={}&token={}".\
-        format(api.config.competition_urls[0], user["uid"], token_value)
+        format(settings["competition_url"], user["uid"], token_value)
 
     body = """
 Welcome to {0}!
@@ -134,9 +136,9 @@ Verification link: {1}
 
 Good luck and have fun!
 The {0} Team.
-    """.format(api.config.competition_name, verification_link)
+    """.format(settings["competition_name"], verification_link)
 
-    subject = "{} Account Verification".format(api.config.competition_name)
+    subject = "{} Account Verification".format(settings["competition_name"])
 
     message = Message(body=body, recipients=[user['email']], subject=subject)
     mail.send(message)
@@ -147,6 +149,7 @@ def send_email_invite(gid, email, teacher=False):
     Sends an email registration link that will automatically join into a group. This link will bypass the email filter.
     """
 
+    settings = api.config.get_settings()
     group = api.group.get_group(gid=gid)
 
     token_value = api.token.set_token({
@@ -156,7 +159,7 @@ def send_email_invite(gid, email, teacher=False):
     }, "registration_token")
 
     registration_link = "{}/#g={}&r={}".\
-        format(api.config.competition_urls[0], group["gid"], token_value)
+        format(settings["competition_url"], group["gid"], token_value)
 
     body = """
 You have been invited by the staff of the {1} organization to compete in {0}.
@@ -168,9 +171,9 @@ Registration link: {2}
 
 Good luck!
   The {0} Team.
-    """.format(api.config.competition_name, group["name"], registration_link)
+    """.format(settings["competition_name"], group["name"], registration_link)
 
-    subject = "{} Registration".format(api.config.competition_name)
+    subject = "{} Registration".format(settings["competition_name"])
 
     message = Message(body=body, recipients=[email], subject=subject)
     mail.send(message)

--- a/picoCTF-web/api/logger.py
+++ b/picoCTF-web/api/logger.py
@@ -157,7 +157,7 @@ class SevereHandler(logging.handlers.SMTPHandler):
             mailhost=settings["email"]["smtp_url"],
             fromaddr=settings["email"]["from_addr"],
             toaddrs=settings["logging"]["admin_emails"],
-            subject="Critical Error in {}".format(api.config.competition_name),
+            subject="Critical Error in {}".format(settings["competition_name"]),
             credentials=(settings["email"]["email_username"],
                          settings["email"]["email_password"]),
             secure=())

--- a/picoCTF-web/api/routes/admin.py
+++ b/picoCTF-web/api/routes/admin.py
@@ -194,4 +194,6 @@ def get_settings():
 def change_settings():
     data = bson.json_util.loads(request.form["json"])
     api.config.change_settings(data)
+    # Update Flask app settings (necessary for email to work)
+    api.app.config_app()
     return WebSuccess("Settings updated")

--- a/picoCTF-web/web/coffee/management-settings.coffee
+++ b/picoCTF-web/web/coffee/management-settings.coffee
@@ -22,6 +22,16 @@ GeneralTab = React.createClass
       $set:
         enable_feedback: !@state.enable_feedback
 
+  updateCompetitionName: (e) ->
+    @setState update @state,
+      $set:
+        competition_name: e.target.value
+
+  updateCompetitionURL: (e) ->
+    @setState update @state,
+      $set:
+        competition_url: e.target.value
+
   updateStartTime: (value) ->
     @setState update @state,
       $set:
@@ -45,11 +55,17 @@ GeneralTab = React.createClass
     feedbackDescription = "Users will be able to review problems when this feature is enabled. The ratings will be available to you
       on the Problem tab."
 
+    competitionNameDescription = "The name of the competition."
+    competitionURLDescription = "The base URL for the competition website. This must be set in order for users to reset
+      their passwords."
+
     startTimeDescription = "Before the competition has started, users will be able to register without viewing the problems."
     endTimeDescription = "After the competition has ended, users will no longer be able to submit keys to the challenges."
 
     <Well>
       <BooleanEntry name="Receive Problem Feedback" value={@state.enable_feedback} onChange=@toggleFeedbackEnabled description={feedbackDescription}/>
+      <TextEntry name="Competition Name" value={@state.competition_name} type="text" onChange=@updateCompetitionName description={competitionNameDescription}/>
+      <TextEntry name="Competition URL" value={@state.competition_url} type="text" onChange=@updateCompetitionURL description={competitionURLDescription}/>
       <TimeEntry name="Competition Start Time" value={@state.start_time["$date"]} onChange=@updateStartTime description={startTimeDescription}/>
       <TimeEntry name="Competition End Time" value={@state.end_time["$date"]} onChange=@updateEndTime description={endTimeDescription}/>
 
@@ -215,6 +231,8 @@ SettingsTab = React.createClass
         $date: 0
       end_time:
         $date: 0
+      competition_name: ""
+      competition_url: ""
       enable_feedback: true
       email:
         email_verification: false
@@ -250,6 +268,8 @@ SettingsTab = React.createClass
   render: ->
     generalSettings =
       enable_feedback: @state.settings.enable_feedback
+      competition_name: @state.settings.competition_name
+      competition_url: @state.settings.competition_url
       start_time: @state.settings.start_time
       end_time: @state.settings.end_time
 


### PR DESCRIPTION
Issue #21 

Email can now be configured from the web interface. Added blank fields for competition_urls and competition_name because more things are broken than just email.py; this needs to be fixed.