### PR TITLE
Fix ctf-daemon unclosed ssh connections

### DIFF
--- a/picoCTF-web/daemons/share_instances.py
+++ b/picoCTF-web/daemons/share_instances.py
@@ -139,7 +139,8 @@ def run():
                 print("Couldn't run script to create symlinks")
 
             try:
-                shell.run(["sudo", "rm", "-r", temp_dir])
+                with shell:
+                    shell.run(["sudo", "rm", "-r", temp_dir])
             except api.common.WebException as e:
                 print("Couldn't remove temporary directory on shell server")
             except Exception as e:


### PR DESCRIPTION
Resolves #143. The final shell cmd was not executed by a `with` statement,
leaving lingering ssh session with every 60s run of the ctf-daemon.