### PR TITLE
Accept both intended flags and DEBUG_KEY

### DIFF
--- a/picoCTF-web/api/problem.py
+++ b/picoCTF-web/api/problem.py
@@ -388,9 +388,9 @@ def grade_problem(pid, key, tid=None):
     problem = get_problem(pid=pid)
     instance = get_instance_data(pid, tid)
 
-    correct_key = instance['flag'] if DEBUG_KEY is None else DEBUG_KEY
-
-    correct = correct_key in key
+    correct = instance['flag'] in key
+    if not correct and DEBUG_KEY is not None:
+        correct = DEBUG_KEY in key
 
     return {
         "correct": correct,


### PR DESCRIPTION
The old behavior does not accept the intended flag if DEBUG_KEY is set.
That behavior makes testing less smooth because it requires restarting
the web service to switch between accepting DEBUG_KEY for platform
testing and accepting the intended flags for problem testing. This patch
makes both types of testing possible with one VM.