### PR TITLE
Add team password reset function

### DIFF
--- a/picoCTF-web/api/logger.py
+++ b/picoCTF-web/api/logger.py
@@ -73,6 +73,8 @@ class StatsHandler(logging.StreamHandler):
             },
         "api.user.update_password_request":
             lambda params, uid=None, check_current=False, result=None: {},
+        "api.team.update_password_request":
+            lambda params, result=None: {},
         "api.email.request_password_reset":
             lambda username, result=None: {},
         "api.team.create_team":

--- a/picoCTF-web/api/routes/team.py
+++ b/picoCTF-web/api/routes/team.py
@@ -34,6 +34,15 @@ def create_new_team_hook():
     return WebSuccess("You now belong to your newly created team.")
 
 
+@blueprint.route('/update_password', methods=['POST'])
+@api_wrapper
+@check_csrf
+@require_login
+def update_team_password_hook():
+    api.team.update_password_request(api.common.flat_multi(request.form))
+    return WebSuccess("Your team password has been successfully updated!")
+
+
 @blueprint.route('/join', methods=['POST'])
 @api_wrapper
 @require_login

--- a/picoCTF-web/api/team.py
+++ b/picoCTF-web/api/team.py
@@ -36,6 +36,14 @@ join_team_schema = Schema(
     },
     extra=True)
 
+update_team_schema = Schema(
+    {
+        Required("new-password"):
+        check(("Passwords must be between 3 and 20 characters.",
+               [str, Length(min=3, max=20)]))
+    },
+    extra=True)
+
 
 def get_team(tid=None, name=None):
     """
@@ -416,6 +424,7 @@ def update_password_request(params):
             new-password-confirmation: confirmation of password
     """
 
+    validate(update_team_schema, params)
     user = api.user.get_user()
     current_team = api.team.get_team(tid=user["tid"])
     if current_team["team_name"] == user["username"]:
@@ -440,8 +449,4 @@ def update_password(tid, password):
     """
 
     db = api.common.get_conn()
-    db.teams.update({
-        'tid': tid
-    }, {'$set': {
-        'password': password
-    }})
+    db.teams.update({'tid': tid}, {'$set': {'password': password}})

--- a/picoCTF-web/api/team.py
+++ b/picoCTF-web/api/team.py
@@ -402,3 +402,46 @@ def join_team(team_name, password, uid=None):
     else:
         raise InternalException(
             "That is not the correct password to join that team.")
+
+
+@log_action
+def update_password_request(params):
+    """
+    Update team password.
+    Assumes args are keys in params.
+
+    Args:
+        params:
+            new-password: the new password
+            new-password-confirmation: confirmation of password
+    """
+
+    user = api.user.get_user()
+    current_team = api.team.get_team(tid=user["tid"])
+    if current_team["team_name"] == user["username"]:
+        raise WebException("You have not created a team yet.")
+
+    if params["new-password"] != params["new-password-confirmation"]:
+        raise WebException("Your team passwords do not match.")
+
+    if len(params["new-password"]) == 0:
+        raise WebException("Your team password cannot be empty.")
+
+    update_password(user["tid"], params["new-password"])
+
+
+def update_password(tid, password):
+    """
+    Updates a team's password.
+
+    Args:
+        tid: teams's uid.
+        password: the new user password.
+    """
+
+    db = api.common.get_conn()
+    db.teams.update({
+        'tid': tid
+    }, {'$set': {
+        'password': password
+    }})

--- a/picoCTF-web/api/user.py
+++ b/picoCTF-web/api/user.py
@@ -96,6 +96,7 @@ user_schema = Schema(
     },
     extra=True)
 
+# RETIRE: this concept has been moved to team.py in 56a1fca
 new_team_schema = Schema(
     {
         Required('team-name-new'):
@@ -109,6 +110,7 @@ new_team_schema = Schema(
     },
     extra=True)
 
+# RETIRE: this concept has been moved to team.py in 5265701
 existing_team_schema = Schema({
     Required('team-name-existing'): check(
         ("Existing team names must be between 3 and 50 characters.", [str, Length(min=3, max=50)]),


### PR DESCRIPTION
Allows anyone in team to set new team password.

Changes `/account` page to show current Join/Register team interface if no
team has been joined/created, but new Change Team Password interface if
a team has been joined/created.

Resolves #168