### PR TITLE
Fix empty-form team registration

### DIFF
--- a/picoCTF-web/web/coffee/account.coffee
+++ b/picoCTF-web/web/coffee/account.coffee
@@ -65,7 +65,7 @@ TeamManagementForm = React.createClass
   onTeamRegistration: (e) ->
     e.preventDefault()
     if (!@state.team_name || !@state.team_password)
-      apiNotify({status: 0, message: "Invalid Team name or password."})
+      apiNotify({status: 0, message: "Invalid team name or password."})
     else
       apiCall "POST", "/api/team/create", {team_name: @state.team_name, team_password: @state.team_password}
       .done (resp) ->

--- a/picoCTF-web/web/coffee/account.coffee
+++ b/picoCTF-web/web/coffee/account.coffee
@@ -46,6 +46,8 @@ TeamManagementForm = React.createClass
   getInitialState: ->
     user: {}
     team: {}
+    team_name: ""
+    team_password: ""
 
   componentWillMount: ->
     apiCall "GET", "/api/user/status"
@@ -62,13 +64,16 @@ TeamManagementForm = React.createClass
 
   onTeamRegistration: (e) ->
     e.preventDefault()
-    apiCall "POST", "/api/team/create", {team_name: @state.team_name, team_password: @state.team_password}
-    .done (resp) ->
-      switch resp.status
-        when 0
-            apiNotify resp
-        when 1
-            document.location.href = "/profile"
+    if (!@state.team_name || !@state.team_password)
+      apiNotify({status: 0, message: "Invalid Team name or password."})
+    else
+      apiCall "POST", "/api/team/create", {team_name: @state.team_name, team_password: @state.team_password}
+      .done (resp) ->
+        switch resp.status
+          when 0
+              apiNotify resp
+          when 1
+              document.location.href = "/profile"
 
   onTeamJoin: (e) ->
     e.preventDefault()

--- a/picoCTF-web/web/coffee/front-page.coffee
+++ b/picoCTF-web/web/coffee/front-page.coffee
@@ -108,17 +108,21 @@ TeamManagementForm = React.createClass
   mixins: [React.addons.LinkedStateMixin]
 
   getInitialState: ->
-    {}
+    team_name: ""
+    team_password: ""
 
   onTeamRegistration: (e) ->
     e.preventDefault()
-    apiCall "POST", "/api/team/create", {team_name: @state.team_name, team_password: @state.team_password}
-    .done (resp) ->
-      switch resp.status
-        when 0
-            apiNotify resp
-        when 1
-            document.location.href = "/profile"
+    if (!@state.team_name || !@state.team_password)
+      apiNotify({status: 0, message: "Invalid Team name or password."})
+    else
+      apiCall "POST", "/api/team/create", {team_name: @state.team_name, team_password: @state.team_password}
+      .done (resp) ->
+        switch resp.status
+          when 0
+              apiNotify resp
+          when 1
+              document.location.href = "/profile"
 
   onTeamJoin: (e) ->
     e.preventDefault()

--- a/picoCTF-web/web/coffee/front-page.coffee
+++ b/picoCTF-web/web/coffee/front-page.coffee
@@ -114,7 +114,7 @@ TeamManagementForm = React.createClass
   onTeamRegistration: (e) ->
     e.preventDefault()
     if (!@state.team_name || !@state.team_password)
-      apiNotify({status: 0, message: "Invalid Team name or password."})
+      apiNotify({status: 0, message: "Invalid team name or password."})
     else
       apiCall "POST", "/api/team/create", {team_name: @state.team_name, team_password: @state.team_password}
       .done (resp) ->


### PR DESCRIPTION
The team Join/Register form has a one-off bug where the default
HTML form `action` is to join, and the secondary the Register
function just calls a POST with params. The latter does not go
through form validation, so teamname or teampass could be omitted
as key, causing a nonspecific server error. This is now validated
client-side. This form is present on front-page (after reg) as well
as the account page.