### PR TITLE
Hash team passwords

### DIFF
--- a/picoCTF-web/api/common.py
+++ b/picoCTF-web/api/common.py
@@ -3,6 +3,7 @@ import uuid
 from hashlib import md5
 
 import api
+import bcrypt
 from pymongo import MongoClient
 from pymongo.errors import ConnectionFailure, InvalidName
 from voluptuous import Invalid, MultipleInvalid
@@ -206,3 +207,16 @@ def safe_fail(f, *args, **kwargs):
         return f(*args, **kwargs)
     except APIException:
         return None
+
+
+def hash_password(password):
+    """
+    Hash plaintext password.
+
+    Args:
+        password: plaintext password
+    Returns:
+        Secure hash of password.
+    """
+
+    return bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt(8))

--- a/picoCTF-web/api/user.py
+++ b/picoCTF-web/api/user.py
@@ -9,7 +9,6 @@ import urllib.parse
 import urllib.request
 
 import api
-import bcrypt
 import flask
 from api.annotations import log_action
 from api.common import (check, InternalException, safe_fail, validate,
@@ -123,19 +122,6 @@ existing_team_schema = Schema({
     Required('team-password-existing'):
         check(("Team passwords must be between 3 and 50 characters.", [str, Length(min=3, max=50)]))
 }, extra=True)
-
-
-def hash_password(password):
-    """
-    Hash plaintext password.
-
-    Args:
-        password: plaintext password
-    Returns:
-        Secure hash of password.
-    """
-
-    return bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt(8))
 
 
 def get_team(uid=None):
@@ -391,7 +377,7 @@ def create_simple_user_request(params):
         params["firstname"],
         params["lastname"],
         params["email"],
-        hash_password(params["password"]),
+        api.common.hash_password(params["password"]),
         team["tid"],
         country=params["country"],
         teacher=user_is_teacher,
@@ -498,14 +484,14 @@ def update_password(uid, password):
 
     Args:
         uid: user's uid.
-        password: the new user password.
+        password: the new user unhashed password.
     """
 
     db = api.common.get_conn()
     db.users.update({
         'uid': uid
     }, {'$set': {
-        'password_hash': hash_password(password)
+        'password_hash': api.common.hash_password(password)
     }})
 
 

--- a/picoCTF-web/test/test_data/data_fabrication.py
+++ b/picoCTF-web/test/test_data/data_fabrication.py
@@ -24,7 +24,7 @@ admin_uid = api.user.create_user(
     "admin",
     "admin",
     "admin@test.com",
-    api.user.hash_password("password"),
+    api.common.hash_password("password"),
     admin_tid,
     admin=True,
     teacher=True)


### PR DESCRIPTION
Move hashing function from `user` module to `common`
TODO: Update all team tests

IMPORTANT: If you have existing teams created in plaintext, the
following script will hash all plaintext team passwords and is
safe to run more than once. This all applies to the `web` instance.

First, set environment variable:
`APP_SETTINGS_FILE=/picoCTF-web-config/deploy_settings.py`

Then execute this script within the `/picoCTF-env` virtualenv:

```
import api

all_teams = api.team.get_all_teams(show_ineligible=True)
for team in all_teams:
    if isinstance(team["password"], str):
            api.team.update_password(team["tid"], team["password"])

```