### PR TITLE
Default obfuscate_problem_directories to true; resolves #160

### DIFF
--- a/ansible/roles/pico-shell/templates/config.json.j2
+++ b/ansible/roles/pico-shell/templates/config.json.j2
@@ -12,7 +12,7 @@
     "default_user": "hacksports",
     "deploy_secret": "{{ shell_manager_deploy_secret }}",
     "hostname": "{{ shell_ip }}",
-    "obfuscate_problem_directories": false,
+    "obfuscate_problem_directories": true,
     "problem_directory_root": "/problems/",
     "web_root": "/usr/share/nginx/html/",
     "web_server": "{{ web_address_internal }}"

--- a/picoCTF-shell/hacksport/deploy.py
+++ b/picoCTF-shell/hacksport/deploy.py
@@ -293,7 +293,7 @@ def generate_instance_deployment_directory(username):
 
     directory = username
     if deploy_config.obfuscate_problem_directories:
-        directory = md5(
+        directory = username + "_" + md5(
             (username + deploy_config.deploy_secret).encode()).hexdigest()
 
     root_dir = deploy_config.problem_directory_root


### PR DESCRIPTION
Also make the obfuscated directory name a bit more human-friendly by
prepending the username of the problem.

There is no apparent down side to turning this option on by default and
the result is we get difficult-to-guess directory names in `/problems`:

```
root@pico-local-dev-shell:~# ls -1 /problems/
buffer-overflow-1_0_bab40cd8ebd7845e1c4c2951c6f82e1f
buffer-overflow-1_1_f49b6bd5da29513569bd87f98a934fa6
ecb-1_0_73a0108a98d2862a86f4b71534aaf7c3
ecb-1_1_83b2ed9a1806c86219347bc4982a66de
sql-injection-1_0_9e114b246c48eb158b16525f71ae2a00
sql-injection-1_1_10a4b1cdfd3a0f78d0d8b9759e6d69c5
```

(Based on my understanding, the benefit of having such obfuscated
directory names is that there is almost no chance of getting into a
wrong problem directory and thus getting the wrong flag. Of course,
there are also symbolic links in ~/problems/ to further reduce this
chance.)

I have also checked that `share_instances.py` continues to work
correctly:

```
player1@pico-local-dev-shell:~$ ls -l problems/
total 4
lrwxrwxrwx 1 root root 62 Sep 15 22:54 Buffer Overflow 1 -> /problems/buffer-overflow-1_1_f49b6bd5da29513569bd87f98a934fa6
```