### PR TITLE
Clarify error messages when join/create teams

### DIFF
--- a/picoCTF-web/api/team.py
+++ b/picoCTF-web/api/team.py
@@ -14,10 +14,10 @@ new_team_schema = Schema(
         check(
             ("The team name must be between 3 and 40 characters.",
              [str, Length(min=3, max=40)]),
+            ("This team name conflicts with an existing user name.",
+             [lambda name: safe_fail(api.user.get_user, name=name) is None]),
             ("A team with that name already exists.",
              [lambda name: safe_fail(api.team.get_team, name=name) is None]),
-            ("A username with that name already exists.",
-             [lambda name: safe_fail(api.user.get_user, name=name) is None]),
         ),
         Required("team_password"):
         check(("Passwords must be between 3 and 20 characters.",
@@ -28,8 +28,12 @@ new_team_schema = Schema(
 join_team_schema = Schema(
     {
         Required("team_name"):
-        check(("The team name must be between 3 and 40 characters.",
-               [str, Length(min=3, max=40)]),),
+        check(
+            ("The team name must be between 3 and 40 characters.",
+               [str, Length(min=3, max=40)]),
+            ("This team name conflicts with an existing user name.",
+             [lambda name: safe_fail(api.user.get_user, name=name) is None]),
+        ),
         Required("team_password"):
         check(("Passwords must be between 3 and 20 characters.",
                [str, Length(min=3, max=20)]))

--- a/picoCTF-web/web/coffee/account.coffee
+++ b/picoCTF-web/web/coffee/account.coffee
@@ -134,6 +134,7 @@ TeamManagementForm = React.createClass
         </Panel>
       else
         <Panel header="Team Management">
+        <p>To avoid confusion on the scoreboard, you may not create a team that shares the same name as an existing user.</p>
           <form onSubmit={@onTeamJoin}>
             <Input type="text" valueLink={@linkState "team_name"} addonBefore={towerGlyph} label="Team Name" required/>
             <Input type="password" valueLink={@linkState "team_password"} addonBefore={lockGlyph} label="Team Password" required/>

--- a/picoCTF-web/web/coffee/front-page.coffee
+++ b/picoCTF-web/web/coffee/front-page.coffee
@@ -140,6 +140,7 @@ TeamManagementForm = React.createClass
     lockGlyph = <Glyphicon glyph="lock"/>
 
     <Panel>
+      <p>To avoid confusion on the scoreboard, you may not create a team that shares the same name as an existing user.</p>
       <form onSubmit={@onTeamJoin}>
         <Input type="text" valueLink={@linkState "team_name"} addonBefore={towerGlyph} label="Team Name" required/>
         <Input type="password" valueLink={@linkState "team_password"} addonBefore={lockGlyph} label="Team Password" required/>


### PR DESCRIPTION
Specifically that a team cannot be created that conflicts with
an existing username. Likewise, an attempt to join a team that does
conflict with an existing username (which is in reality, a user's
starting self-team) receives the same error. The user check is
performed first when validating a team creation so that the
later team name check and "Team already exists" message does
not create confusion.