### PR TITLE
Add shell_server sharding by problems instances

### DIFF
--- a/ansible/scripts/add_shell_server.py
+++ b/ansible/scripts/add_shell_server.py
@@ -11,7 +11,7 @@ import sys
 import api
 
 
-def main(name, host, user, password, port, protocol):
+def main(name, host, user, password, port, proto):
     try:
         # If a server by this name exists no action necessary
         api.shell_servers.get_server(name=name)
@@ -23,7 +23,8 @@ def main(name, host, user, password, port, protocol):
                 "port": port,
                 "username": user,
                 "password": password,
-                "protocol": proto
+                "protocol": proto,
+                "server_number": 1
             })
         except Exception as e:
             print(e)

--- a/picoCTF-web/api/config.py
+++ b/picoCTF-web/api/config.py
@@ -154,6 +154,13 @@ default_settings = {
     "logging": {
         "admin_emails": ["ben@example.com", "joe@example.com"],
         "critical_error_timeout": 600
+    },
+
+    # SHELL SERVERS
+    "shell_servers": {
+        "enable_sharding": False,
+        "default_stepping": 5000,
+        "steps": [7500, 12500, 17500],
     }
 }
 """ Helper functions to get settings. Do not change these """

--- a/picoCTF-web/api/config.py
+++ b/picoCTF-web/api/config.py
@@ -161,6 +161,7 @@ default_settings = {
         "enable_sharding": False,
         "default_stepping": 5000,
         "steps": [7500, 12500, 17500],
+        "limit_added_range": False,
     }
 }
 """ Helper functions to get settings. Do not change these """

--- a/picoCTF-web/api/problem.py
+++ b/picoCTF-web/api/problem.py
@@ -307,7 +307,7 @@ def assign_instance_to_team(pid, tid=None, reassign=False):
     settings = api.config.get_settings()
     if settings["shell_servers"]["enable_sharding"]:
         available_instances = list(
-            filter(lambda i: i["server_number"] == team["server_number"],
+            filter(lambda i: i.get("server_number") == team.get("server_number", 1),
                    problem["instances"]))
 
     if pid in team["instances"] and not reassign:

--- a/picoCTF-web/api/problem.py
+++ b/picoCTF-web/api/problem.py
@@ -148,9 +148,8 @@ def set_instance_ids(problem, sid):
         instance["iid"] = api.common.hash(
             str(instance["instance_number"]) + sid + problem["pid"])
         instance["sid"] = sid
-        if server_number:
+        if server_number is not None:
             instance["server_number"] = server_number
-
 
 
 def insert_problem(problem, sid=None):

--- a/picoCTF-web/api/problem.py
+++ b/picoCTF-web/api/problem.py
@@ -142,16 +142,15 @@ def set_instance_ids(problem, sid):
     Generate the instance ids for a set of problems.
     """
 
-    settings = api.config.get_settings()
-    if settings["shell_servers"]["enable_sharding"]:
-        server_number = api.shell_servers.get_server_number(sid)
+    server_number = api.shell_servers.get_server_number(sid)
 
     for instance in problem["instances"]:
         instance["iid"] = api.common.hash(
             str(instance["instance_number"]) + sid + problem["pid"])
         instance["sid"] = sid
-        if settings["shell_servers"]["enable_sharding"]:
+        if server_number:
             instance["server_number"] = server_number
+
 
 
 def insert_problem(problem, sid=None):

--- a/picoCTF-web/api/problem.py
+++ b/picoCTF-web/api/problem.py
@@ -142,10 +142,16 @@ def set_instance_ids(problem, sid):
     Generate the instance ids for a set of problems.
     """
 
+    settings = api.config.get_settings()
+    if settings["shell_servers"]["enable_sharding"]:
+        server_number = api.shell_servers.get_server_number(sid)
+
     for instance in problem["instances"]:
         instance["iid"] = api.common.hash(
             str(instance["instance_number"]) + sid + problem["pid"])
         instance["sid"] = sid
+        if settings["shell_servers"]["enable_sharding"]:
+            instance["server_number"] = server_number
 
 
 def insert_problem(problem, sid=None):
@@ -296,17 +302,30 @@ def assign_instance_to_team(pid, tid=None, reassign=False):
     team = api.team.get_team(tid=tid)
     problem = get_problem(pid=pid)
 
+    available_instances = problem["instances"]
+
+    settings = api.config.get_settings()
+    if settings["shell_servers"]["enable_sharding"]:
+        available_instances = list(
+            filter(lambda i: i["server_number"] == team["server_number"],
+                   problem["instances"]))
+
     if pid in team["instances"] and not reassign:
         raise InternalException(
             "Team with tid {} already has an instance of pid {}.".format(
                 tid, pid))
 
-    if len(problem["instances"]) == 0:
-        raise InternalException(
-            "Problem {} has no instances to assign.".format(pid))
+    if len(available_instances) == 0:
+        if settings["shell_servers"]["enable_sharding"]:
+            raise InternalException(
+                "Your assigned shell server is currently down. Please contact an admin."
+            )
+        else:
+            raise InternalException(
+                "Problem {} has no instances to assign.".format(pid))
 
-    instance_number = randint(0, len(problem["instances"]) - 1)
-    iid = problem["instances"][instance_number]["iid"]
+    instance_number = randint(0, len(available_instances) - 1)
+    iid = available_instances[instance_number]["iid"]
 
     team["instances"][pid] = iid
 

--- a/picoCTF-web/api/routes/admin.py
+++ b/picoCTF-web/api/routes/admin.py
@@ -90,7 +90,7 @@ def change_problem_availability_hook():
 @api_wrapper
 @require_admin
 def get_shell_servers():
-    return WebSuccess(data=api.shell_servers.get_servers())
+    return WebSuccess(data=api.shell_servers.get_servers(get_all=True))
 
 
 @blueprint.route("/shell_servers/add", methods=["POST"])

--- a/picoCTF-web/api/routes/admin.py
+++ b/picoCTF-web/api/routes/admin.py
@@ -160,6 +160,25 @@ def check_status_of_shell_server():
             data=data)
 
 
+@blueprint.route("/shell_servers/reassign_teams", methods=['POST'])
+@api_wrapper
+@require_admin
+def reassign_teams_hook():
+    if not api.config.get_settings()["shell_servers"]["enable_sharding"]:
+        return WebError(
+            "Enable sharding first before assigning server numbers.")
+    else:
+        include_assigned = request.form.get("include_assigned", None)
+        if include_assigned is None:
+            return WebError(
+                "You must specify whether to reassigned already-assigned teams."
+            )
+        else:
+            count = api.shell_servers.reassign_teams(
+                include_assigned=include_assigned)
+            return WebSuccess(str(count) + " teams reassigned.")
+
+
 @blueprint.route("/bundle/dependencies_active", methods=["POST"])
 @api_wrapper
 @require_admin

--- a/picoCTF-web/api/routes/admin.py
+++ b/picoCTF-web/api/routes/admin.py
@@ -168,15 +168,14 @@ def reassign_teams_hook():
         return WebError(
             "Enable sharding first before assigning server numbers.")
     else:
-        include_assigned = request.form.get("include_assigned", None)
-        if include_assigned is None:
-            return WebError(
-                "You must specify whether to reassigned already-assigned teams."
-            )
+        include_assigned = request.form.get("include_assigned", False)
+        count = api.shell_servers.reassign_teams(
+            include_assigned=include_assigned)
+        if include_assigned:
+            action = "reassigned."
         else:
-            count = api.shell_servers.reassign_teams(
-                include_assigned=include_assigned)
-            return WebSuccess(str(count) + " teams reassigned.")
+            action = "assigned."
+        return WebSuccess(str(count) + " teams " + action)
 
 
 @blueprint.route("/bundle/dependencies_active", methods=["POST"])

--- a/picoCTF-web/api/shell_servers.py
+++ b/picoCTF-web/api/shell_servers.py
@@ -296,7 +296,7 @@ def load_problems_from_server(sid):
     return len(list(filter(has_instances, data["problems"])))
 
 
-def assign_server_number():
+def assign_server_number(new_team=True, tid=None):
     """
     Assigns a server number based on current teams count and
     configured stepping
@@ -307,7 +307,16 @@ def assign_server_number():
     settings = api.config.get_settings()["shell_servers"]
     db = api.common.get_conn()
 
-    team_count = db.teams.count()
+    if new_team:
+        team_count = db.teams.count()
+    else:
+        if not tid:
+            raise InternalException("tid must be specified.")
+        oid = db.teams.find_one({"tid": tid}, {"_id": 1})
+        if not oid:
+            raise InternalException("Invalid tid.")
+        team_count = db.teams.count({"_id": {"$lt": oid["_id"]}})
+
     assigned_number = 1
 
     steps = settings["steps"]

--- a/picoCTF-web/api/shell_servers.py
+++ b/picoCTF-web/api/shell_servers.py
@@ -32,8 +32,8 @@ server_schema = Schema(
                [lambda x: x in ['HTTP', 'HTTPS']])),
         "server_number":
         check(("Server number must be an integer.", [int]),
-              ("Server number must be a valid integer.",
-              [lambda x: 0 < int(x)])),
+              ("Server number must be a positive integer.",
+               [lambda x: 0 < int(x)])),
     },
     extra=True)
 
@@ -142,6 +142,8 @@ def add_server(params):
 
     if isinstance(params["port"], str):
         params["port"] = int(params["port"])
+    if isinstance(params.get("server_number"), str):
+        params["server_number"] = int(params["server_number"])
 
     if safe_fail(get_server, name=params["name"]) is not None:
         raise WebException("Shell server with this name already exists")
@@ -186,6 +188,8 @@ def update_server(sid, params):
 
     if isinstance(params["port"], str):
         params["port"] = int(params["port"])
+    if isinstance(params.get("server_number"), str):
+        params["server_number"] = int(params["server_number"])
 
     db.shell_servers.update({"sid": server["sid"]}, {"$set": params})
 

--- a/picoCTF-web/api/shell_servers.py
+++ b/picoCTF-web/api/shell_servers.py
@@ -363,10 +363,14 @@ def reassign_teams(include_assigned=False):
     for team in teams:
         server_number = get_assigned_server_number(
             new_team=False, tid=team["tid"])
+        # Set server_number and clear instances
         db.teams.update({
             'tid': team["tid"]
         }, {'$set': {
-            'server_number': server_number
+            'server_number': server_number,
+            'instances': {}
         }})
+        # Re-assign instances
+        safe_fail(api.problem.get_visible_problems, team["tid"])
 
     return len(teams)

--- a/picoCTF-web/api/shell_servers.py
+++ b/picoCTF-web/api/shell_servers.py
@@ -218,7 +218,7 @@ def get_servers(get_all=False):
     settings = api.config.get_settings()
     match = {}
     if not get_all and settings["shell_servers"]["enable_sharding"]:
-        server_number = api.team.get_team()["server_assignment"]
+        server_number = api.team.get_team()["server_number"]
         match = {"server_number": server_number}
     return list(db.shell_servers.find(match, {"_id": 0}))
 

--- a/picoCTF-web/api/shell_servers.py
+++ b/picoCTF-web/api/shell_servers.py
@@ -361,16 +361,17 @@ def reassign_teams(include_assigned=False):
             }))
 
     for team in teams:
+        old_server_number = team.get("server_number")
         server_number = get_assigned_server_number(
             new_team=False, tid=team["tid"])
-        # Set server_number and clear instances
-        db.teams.update({
-            'tid': team["tid"]
-        }, {'$set': {
-            'server_number': server_number,
-            'instances': {}
-        }})
-        # Re-assign instances
-        safe_fail(api.problem.get_visible_problems, team["tid"])
+        if old_server_number != server_number:
+            db.teams.update({
+                'tid': team["tid"]
+            }, {'$set': {
+                'server_number': server_number,
+                'instances': {}
+            }})
+            # Re-assign instances
+            safe_fail(api.problem.get_visible_problems, team["tid"])
 
     return len(teams)

--- a/picoCTF-web/api/shell_servers.py
+++ b/picoCTF-web/api/shell_servers.py
@@ -224,7 +224,15 @@ def get_servers(get_all=False):
     if not get_all and settings["shell_servers"]["enable_sharding"]:
         team = api.team.get_team()
         match = {"server_number": team.get("server_number", 1)}
-    return list(db.shell_servers.find(match, {"_id": 0}))
+
+    servers = list(db.shell_servers.find(match, {"_id": 0}))
+
+    if len(servers) == 0 and settings["shell_servers"]["enable_sharding"]:
+        raise InternalException(
+            "Your assigned shell server is currently down. Please contact an admin."
+        )
+
+    return servers
 
 
 def get_problem_status_from_server(sid):

--- a/picoCTF-web/api/shell_servers.py
+++ b/picoCTF-web/api/shell_servers.py
@@ -67,7 +67,7 @@ def get_server(sid=None, name=None):
 
 def get_server_number(sid):
     """
-    Gets the server_number designation
+    Gets the server_number designation from sid
     """
     if sid is None:
         raise InternalException("You must specify a sid")
@@ -77,7 +77,7 @@ def get_server_number(sid):
         raise InternalException(
             "Server with sid '{}' does not exist".format(sid))
 
-    return server["server_number"]
+    return server.get("server_number")
 
 
 def get_connection(sid):
@@ -214,7 +214,7 @@ def remove_server(sid):
 def get_servers(get_all=False):
     """
     Returns the list of added shell servers, or the assigned shell server
-    shard if sharding is enabled
+    shard if sharding is enabled. Defaults to server 1 if not assigned
     """
 
     db = api.common.get_conn()
@@ -222,8 +222,8 @@ def get_servers(get_all=False):
     settings = api.config.get_settings()
     match = {}
     if not get_all and settings["shell_servers"]["enable_sharding"]:
-        server_number = api.team.get_team()["server_number"]
-        match = {"server_number": server_number}
+        team = api.team.get_team()
+        match = {"server_number": team.get("server_number", 1)}
     return list(db.shell_servers.find(match, {"_id": 0}))
 
 

--- a/picoCTF-web/api/team.py
+++ b/picoCTF-web/api/team.py
@@ -192,7 +192,7 @@ def create_team(params):
 
     settings = api.config.get_settings()
     if settings["shell_servers"]["enable_sharding"]:
-        params['server_number'] = api.shell_servers.assign_server_number(
+        params['server_number'] = api.shell_servers.get_assigned_server_number(
             new_team=True)
 
     db.teams.insert(params)

--- a/picoCTF-web/api/team.py
+++ b/picoCTF-web/api/team.py
@@ -190,6 +190,10 @@ def create_team(params):
     params['size'] = 0
     params['instances'] = {}
 
+    settings = api.config.get_settings()
+    if settings["shell_servers"]["enable_sharding"]:
+        params['server_number'] = api.shell_servers.assign_server_number()
+
     db.teams.insert(params)
 
     return params['tid']

--- a/picoCTF-web/api/team.py
+++ b/picoCTF-web/api/team.py
@@ -192,7 +192,8 @@ def create_team(params):
 
     settings = api.config.get_settings()
     if settings["shell_servers"]["enable_sharding"]:
-        params['server_number'] = api.shell_servers.assign_server_number()
+        params['server_number'] = api.shell_servers.assign_server_number(
+            new_team=True)
 
     db.teams.insert(params)
 

--- a/picoCTF-web/web/coffee/management-settings.coffee
+++ b/picoCTF-web/web/coffee/management-settings.coffee
@@ -269,11 +269,29 @@ ShardingTab = React.createClass
       @props.refresh()
     ).bind(this)
 
+  assignServerNumbers: ->
+    confirmDialog("This will assign server_numbers to all unassigned teams. This may include teams previously defaulted to server_number 1 and already given problem instances!", "Assign Server Numbers Confirmation", "Assign Server Numbers", "Cancel",
+    () ->
+      apiCall "POST", "/api/admin/shell_servers/reassign_teams", {}
+      .done (data) ->
+        apiNotify data
+    , () ->
+    )
+
+  reassignServerNumbers: ->
+    confirmDialog("This will reassign all teams. Problem instances will be randomized for any teams that change servers!", "Reassign Server Numbers Confirmation", "Reassign Server Numbers", "Cancel",
+    () ->
+      apiCall "POST", "/api/admin/shell_servers/reassign_teams", {"include_assigned": "True"}
+      .done (data) ->
+        apiNotify data
+    , () ->
+    )
+
   render: ->
     shardingDescription = "Sharding splits teams to different shell_servers based on stepping"
     defaultSteppingDescription = "Default stepping, applied after defined steps"
     stepsDescription = "Comma delimited list of stepping (e.g. '1000,1500,2000')"
-    limitRangeDescription = "Sharding splits teams to different shell_servers based on stepping"
+    limitRangeDescription = "Limit assignments to the highest added server_number"
 
     <Well>
       <Row>
@@ -282,6 +300,7 @@ ShardingTab = React.createClass
           <TextEntry name="Defined Steps" value={@state.steps} type="text" onChange=@updateSteps description={stepsDescription}/>
           <TextEntry name="Default Stepping" value={@state.default_stepping} type="text" onChange=@updateDefaultStepping description={defaultSteppingDescription}/>
           <BooleanEntry name="Limit to Added Range" value={@state.limit_added_range} onChange=@toggleLimitRange description={limitRangeDescription}/>
+          <br/><Button onClick={@assignServerNumbers}>Assign Server Numbers</Button> &nbsp; <Button onClick={@reassignServerNumbers}>Reassign All Server Numbers</Button><br/><br/>
           <Row>
             <div className="text-center">
               <ButtonToolbar>

--- a/picoCTF-web/web/coffee/management-shell.coffee
+++ b/picoCTF-web/web/coffee/management-shell.coffee
@@ -15,7 +15,10 @@ ServerForm = React.createClass
 
   getInitialState: ->
     if @props.new
-      server = {"host": "", "port":22, "username": "", "password": "", "protocol": "HTTP", "name": ""}
+      server = {
+        "host": "", "port": 22, "username": "", "password": "",
+        "protocol": "HTTP", "name": "", "server_number": 1
+      }
     else
       server = @props.server
 
@@ -71,6 +74,11 @@ ServerForm = React.createClass
     copy.password = e.target.value
     @setState {shellServer: copy}
 
+  updateServerNumber: (e) ->
+    copy = @state.shellServer
+    copy.server_number = parseInt(e.target.value)
+    @setState {shellServer: copy}
+
   updateProtocol: (value) ->
     copy = @state.shellServer
     copy.protocol = value
@@ -82,6 +90,7 @@ ServerForm = React.createClass
     portDescription = "The port that SSH is running on."
     usernameDescription = "The username to connect as - Be sure that this user has sudo privileges!"
     passwordDescription = "The password to use for authentication - Be sure that this is password is only used once."
+    serverNumberDescription = "The designated server_number if sharding is enabled."
     protocolDescription = "The web protocol to access the problem files and shell server. This is most often just HTTP."
 
     if @state.new
@@ -104,6 +113,7 @@ ServerForm = React.createClass
       <TextEntry name="SSH Port" type="number" value={@state.shellServer.port.toString()} onChange=@updatePort description={portDescription} />
       <TextEntry name="Username" type="text" value={@state.shellServer.username} onChange=@updateUsername description={usernameDescription} />
       <TextEntry name="Password" type="password" value={@state.shellServer.password} onChange=@updatePassword description={passwordDescription} />
+      <TextEntry name="Server Number" type="number" value={@state.shellServer.server_number.toString()} onChange=@updateServerNumber description={serverNumberDescription} />
       <OptionEntry name="Web Protocol" value={@state.shellServer.protocol} options={["HTTP", "HTTPS"]} onChange=@updateProtocol description={protocolDescription} />
       {buttons}
     </div>

--- a/picoCTF-web/web/coffee/shell.coffee
+++ b/picoCTF-web/web/coffee/shell.coffee
@@ -2,6 +2,11 @@ renderShellServers = _.template($("#shell-servers-template").remove().text())
 
 $ ->
   apiCall "GET", "/api/user/shell_servers", {}
-  .done (data) ->
-    if data.data
-      $("#shell-servers").html renderShellServers({servers: data.data})
+
+  .done (resp) ->
+    switch resp.status
+      when 0
+          apiNotify resp
+      when 1
+        if resp.data
+          $("#shell-servers").html renderShellServers({servers: resp.data})


### PR DESCRIPTION
Shell servers are tagged with `server_number` upon add,
and their respective problems are tagged with same.

Teams are assigned `server_numbers` based on configured
manual and auto stepping. Subsequent problem instances
assignment is limited to those problem instances on the
teamn's assigned shell server.

Teams that are assigned to not-yet added shell servers
cannot be assigned problem instances and receive an error
to contact admin.