### PR TITLE
Add delegate_to to picoCTF-web synchronization task

### DIFF
--- a/ansible/roles/pico-web/tasks/picoCTF-webapp.yml
+++ b/ansible/roles/pico-web/tasks/picoCTF-webapp.yml
@@ -31,6 +31,7 @@
     src: "{{ pico_web_api_dir }}/"
     dest: "{{ web_build_dir }}"
     delete: yes
+  delegate_to: "{{ inventory_hostname }}"
 
 - name: Run Jekyll to rebuild new web
   shell: "cd {{ web_build_dir }}/web && jekyll build"


### PR DESCRIPTION
This task is intended to synchronize directories on the remote host.
Without the delegate_to it looks in a local path which will fail when
run remotely.

This change has also been tested against the default development vm
using the standard `ansible_local` provisioner.