### PR TITLE
Allow reg of teacher users, class shows realnames

### DIFF
--- a/picoCTF-web/api/group.py
+++ b/picoCTF-web/api/group.py
@@ -312,9 +312,8 @@ def switch_role(gid, tid, role):
     else:
         raise InternalException("Only supported roles are member and teacher.")
 
-    # Disable promotion or demotion of teacher account
-    #for uid in api.team.get_team_uids(tid=team["tid"]):
-    #    sync_teacher_status(tid, uid)
+    for uid in api.team.get_team_uids(tid=team["tid"]):
+        sync_teacher_status(tid, uid)
 
 
 @log_action

--- a/picoCTF-web/api/team.py
+++ b/picoCTF-web/api/team.py
@@ -225,6 +225,8 @@ def get_team_members(tid=None, name=None, show_disabled=True):
             "_id": 0,
             "uid": 1,
             "username": 1,
+            "firstname": 1,
+            "lastname": 1,
             "disabled": 1,
             "email": 1,
             "teacher": 1,
@@ -268,6 +270,9 @@ def get_team_information(tid=None, gid=None):
     """
 
     team_info = get_team(tid=tid)
+    # Sanitize
+    team_info.pop("password", None)
+    team_info.pop("instances", None)
 
     if tid is None:
         tid = team_info["tid"]
@@ -279,6 +284,8 @@ def get_team_information(tid=None, gid=None):
     team_info["score"] = api.stats.get_score(tid=tid)
     team_info["members"] = [{
         "username": member["username"],
+        "firstname": member["firstname"],
+        "lastname": member["lastname"],
         "email": member["email"],
         "uid": member["uid"],
         "affiliation": member.get("affiliation", "None"),
@@ -301,6 +308,9 @@ def get_team_information(tid=None, gid=None):
     for solved_problem in api.problem.get_solved_problems(tid=tid):
         solved_problem.pop("instances", None)
         solved_problem.pop("pkg_dependencies", None)
+        solved_problem.pop("hints", None)
+        solved_problem.pop("author", None)
+        solved_problem.pop("organization", None)
         team_info["solved_problems"].append(solved_problem)
 
     return team_info

--- a/picoCTF-web/web/classroom.html
+++ b/picoCTF-web/web/classroom.html
@@ -179,12 +179,12 @@ post_scripts:
             </div>
           </div>
           <% _.each(_.sortBy(teams, "team_name"), function(team) {
-            members = team.members.map(function(member){ return member.firstname + " " + member.lastname }).join(", ") %>
+            members = team.members.map(function(member){ return window.getName(member.firstname, member.lastname, member.username) }).join(", ") %>
             <div class="row">
               <div class="col-md-12">
                   <div class="problem panel panel-default">
                     <div class="panel-heading team-visualization-enabler" expanded data-tid="<%= team.tid %>" data-toggle="collapse" data-target="#<%= (groupName+team.tid).hashCode() %>">
-                        <%- team.team_name %> (<%- members %>) <div class="pull-right"><%- team.competition_active ? team.score : '' %></div>
+                        <%- team.team_name %> [<%- members %>] <div class="pull-right"><%- team.competition_active ? team.score : '' %></div>
                     </div>
                     <div class="panel-collapse collapse" id="<%= (groupName+team.tid).hashCode() %>">
                       <div class="panel-body">

--- a/picoCTF-web/web/classroom.html
+++ b/picoCTF-web/web/classroom.html
@@ -19,7 +19,7 @@ post_scripts:
                         You are logged into a teacher account, which allows you to manage multiple students grouped together in classes.
                     </p>
                     <p>
-                        You can also provide your username and the name of the class to your students, who join the class on their account on the "Profile" page.
+                        You can also provide the classroom name and the classroom owner username to your students, who join the class on their account on the "Profile" page.
                     </p>
                 </div>
             </div>
@@ -55,7 +55,7 @@ post_scripts:
                                 <strong>Classroom Name</strong>: <%- groupName %>
                             </p>
                             <p>
-                                <strong>Teacher Username</strong>: <%- owner %>
+                                <strong>Classroom Owner Username</strong>: <%- owner %>
                             </p>
                         </div>
                         <% var registrationLink = document.location.origin + "/#g=" + gid; %>

--- a/picoCTF-web/web/classroom.html
+++ b/picoCTF-web/web/classroom.html
@@ -59,10 +59,8 @@ post_scripts:
                             </p>
                         </div>
                         <% var registrationLink = document.location.origin + "/#g=" + gid; %>
-                        <!--
                         <p>Or register with this link to automatically join:</p>
                         <a href="<%= registrationLink %>"><%= registrationLink %></a>
-                        -->
                     </div>
                 </div>
               </div>
@@ -181,7 +179,7 @@ post_scripts:
             </div>
           </div>
           <% _.each(_.sortBy(teams, "team_name"), function(team) {
-            members = team.members.map(function(member){ return member.username }).join(", ") %>
+            members = team.members.map(function(member){ return member.firstname + " " + member.lastname }).join(", ") %>
             <div class="row">
               <div class="col-md-12">
                   <div class="problem panel panel-default">

--- a/picoCTF-web/web/coffee/classroom-management.coffee
+++ b/picoCTF-web/web/coffee/classroom-management.coffee
@@ -113,6 +113,7 @@ MemberManagement = React.createClass
 
     <Panel>
       <h4>User Management</h4>
+      <MemberInvitePanel gid={@props.gid} refresh={@props.refresh}/>
       {memberInformation}
     </Panel>
 
@@ -172,6 +173,7 @@ GroupManagement = React.createClass
       </Col>
       <Col sm={6}>
         <GroupOptions pushUpdates={@pushUpdates} settings={@state.settings} gid={@props.gid}/>
+        <GroupEmailWhitelist emails={@state.settings.email_filter} pushUpdates={@pushUpdates} gid={@props.gid}/>
       </Col>
     </div>
 

--- a/picoCTF-web/web/coffee/classroom.coffee
+++ b/picoCTF-web/web/coffee/classroom.coffee
@@ -12,6 +12,14 @@ String.prototype.hashCode = ->
  		hash = hash & hash
  	hash
 
+@getName = (first, last, user) ->
+  name = (first + " " + last).trim()
+  if (name)
+    name += " (" + user + ")"
+  else
+    name = user
+  return name
+
 createGroupSetup = () ->
     formDialogContents = _.template($("#new-group-template").html())({})
     formDialog formDialogContents, "Create a New Classroom", "OK", "new-group-name", () ->
@@ -27,7 +35,7 @@ createGroupSetup = () ->
       problems = resp.data; # non-admin API only returns non-disabled problems as top level data array
       data = [["Teamname", "Member Name(s)"].concat(_.map(problems, (problem) -> problem.name), ["Total"])]
       _.each teams, ((team) ->
-        members = '"' + team.members.map((member) -> return member.firstname + ' ' + member.lastname).join(", ") + '"'
+        members = '"' + team.members.map((member) -> return this.getName(member.firstname, member.lastname, member.username)).join(", ") + '"'
         teamData = [team.team_name, members]
         teamData = teamData.concat _.map problems, ((problem) ->
           solved = _.find team.solved_problems, (solvedProblem) -> solvedProblem.name == problem.name

--- a/picoCTF-web/web/coffee/classroom.coffee
+++ b/picoCTF-web/web/coffee/classroom.coffee
@@ -25,9 +25,9 @@ createGroupSetup = () ->
     else
       # problems = _.filter resp.data.problems, (problem) -> !problem.disabled
       problems = resp.data; # non-admin API only returns non-disabled problems as top level data array
-      data = [["Teamname", "Usernames"].concat(_.map(problems, (problem) -> problem.name), ["Total"])]
+      data = [["Teamname", "Member Name(s)"].concat(_.map(problems, (problem) -> problem.name), ["Total"])]
       _.each teams, ((team) ->
-        members = '"' + team.members.map((member) -> return member.username).join(", ") + '"'
+        members = '"' + team.members.map((member) -> return member.firstname + ' ' + member.lastname).join(", ") + '"'
         teamData = [team.team_name, members]
         teamData = teamData.concat _.map problems, ((problem) ->
           solved = _.find team.solved_problems, (solvedProblem) -> solvedProblem.name == problem.name

--- a/picoCTF-web/web/coffee/front-page.coffee
+++ b/picoCTF-web/web/coffee/front-page.coffee
@@ -530,7 +530,6 @@ AuthPanel = React.createClass
     status: params.status
     groupName: ""
     captcha: ""
-    eligibility: "eligible"
     regStats: {}
 
   componentWillMount: ->

--- a/picoCTF-web/web/profile.html
+++ b/picoCTF-web/web/profile.html
@@ -71,8 +71,8 @@ startup_functions:
             <input type="text" class="form-control class-class-name" id="group-name-input" placeholder="Classroom Name">
         </div>
         <div class="form-group">
-            <label class="sr-only" for="group-owner-input">Teacher</label>
-            <input type="text" class="form-control class-teacher-username" id="group-owner-input" placeholder="Teacher Username">
+            <label class="sr-only" for="group-owner-input">Classroom Owner Username</label>
+            <input type="text" class="form-control class-teacher-username" id="group-owner-input" placeholder="Classroom Owner Username">
         </div>
         <button class="btn btn-primary" id="join-group">Join</button>
         </div>


### PR DESCRIPTION
Classroom progress panels and CSV columns show teamname and member name(s), allowing for multi-member teams. 

Panel title:
`team1 (alice smith, bob smith)`

CSV: 

Teamname|Member Name(s)
-|-
`team1`|alice smith, bob smith

* Resolves #209 
* Resolves #204 
* Revert eb31ad4 "Remove/hide classroom e-mail invite from UI"
* Partial revert a1aa23f "Additional adjustments to classroom per #181 issues"