### PR TITLE
Add ALLOW_EXTRA to problem schema

### DIFF
--- a/picoCTF-shell/shell_manager/util.py
+++ b/picoCTF-shell/shell_manager/util.py
@@ -11,7 +11,7 @@ from os import chmod, listdir, sep, unlink
 from os.path import isdir, isfile, join
 from shutil import copy2, copytree
 
-from voluptuous import All, Length, MultipleInvalid, Range, Required, Schema
+from voluptuous import All, Length, MultipleInvalid, Range, Required, Schema, ALLOW_EXTRA
 
 logger = logging.getLogger(__name__)
 
@@ -90,7 +90,7 @@ problem_schema = Schema({
     "pkg_dependencies": list,
     "pip_requirements": list,
     "pip_python_version": All(str, Length(min=1, max=3))
-})
+}, extra=ALLOW_EXTRA)
 
 bundle_schema = Schema({
     Required("author"): All(str, Length(min=1, max=32)),


### PR DESCRIPTION
Allows custom fields in problem.json. This does not impact the
validation of the public platform, but does allow flexibility for other
metadata to be recorded.

The voluptuous documentation on this parameter is: https://github.com/alecthomas/voluptuous#extra-dictionary-keys

An example error this MR mitigates is the following, as observed during the use of `shell_manager package`:
```
14:50:34 shell_manager.util CRITICAL: Error validating problem object at '/challenges/ReverseEngineering/Cocoon/problem.json'!
14:50:34 shell_manager.util CRITICAL: extra keys not allowed @ data['creation_date']
```

In this case the `problem.json` included an internally relevant additional field `creation_date`.