### PR TITLE
Add option to sync picoCTF source from local directory

### DIFF
--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -3,3 +3,6 @@
 # and can easily be overridden in group_vars, host_vars, or command line.
 
 private_repo: False
+
+# Method for synchronizing the picoCTF source to the remote machine
+sync_mode: "none"   # [none, git, git_private, source]

--- a/ansible/roles/common/tasks/clone_repo.yml
+++ b/ansible/roles/common/tasks/clone_repo.yml
@@ -26,11 +26,3 @@
     dest: "{{ pico_base_dir}}"
     accept_hostkey: yes
   when: not private_repo
-
-- name: Ensure admin user owns picoCTF directory
-  file:
-    path: "{{ pico_base_dir}}"
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_user }}"
-    state: directory
-    recurse: yes

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -22,6 +22,24 @@
 # be loaded in directly via filesystem sync without being cloned from a
 # specific source and branch
 - include: clone_repo.yml
-  when: "'local_development' not in group_names"
+  when: "'git' in sync_mode"			# coule be git or git_private
   tags:
     - network
+
+# Source should be synchronized over from a local directory on the control machine
+- name: Synchronize picoCTF source code
+  synchronize:
+    src: "{{pico_src_dir}}"
+    dest: "{{pico_base_dir}}"
+    archive: no
+    recursive: yes
+  when: "'source' in sync_mode"
+
+- name: Ensure admin user owns picoCTF directory
+  file:
+    path: "{{ pico_base_dir}}"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    state: directory
+    recurse: yes
+  when: ('git' in sync_mode) or ('source' in sync_mode)


### PR DESCRIPTION
This adds flexibility for remote deployment by allowing an additional mechanism to get the picoCTF source on the remote machine.

This complements the currently available `clone_repo.yml` which uses a public or private git repo.

This also simplifies the default option which is to not synchronize the source code by making it an explicit option, rather than overloading the `local_development` group name.