### PR TITLE
memoize api.stats.get_group_scores with cache daemon

### DIFF
--- a/picoCTF-web/api/routes/stats.py
+++ b/picoCTF-web/api/routes/stats.py
@@ -41,6 +41,7 @@ def get_team_score_progression():
 @api_wrapper
 @block_before_competition(WebError("The competition has not begun yet!"))
 def get_scoreboard_hook():
+
     result = {}
     result['public'] = api.stats.get_all_team_scores(eligible=True)
     result['groups'] = []
@@ -50,13 +51,13 @@ def get_scoreboard_hook():
         if not api.team.get_team(tid=user["tid"])["eligible"]:
             result['ineligible'] = api.stats.get_all_team_scores(eligible=False)
         for group in api.team.get_groups(uid=user["uid"]):
+            # this is called on every scoreboard pageload and should be cached
+            # to support large groups
+            group_scoreboard = api.stats.get_group_scores(gid=group['gid'])
             result['groups'].append({
-                'gid':
-                group['gid'],
-                'name':
-                group['name'],
-                'scoreboard':
-                api.stats.get_group_scores(gid=group['gid'])
+                'gid': group['gid'],
+                'name': group['name'],
+                'scoreboard': group_scoreboard
             })
 
     return WebSuccess(data=result)

--- a/picoCTF-web/api/stats.py
+++ b/picoCTF-web/api/stats.py
@@ -42,6 +42,9 @@ def get_team_review_count(tid=None, uid=None):
         return count
 
 
+# This is on the /scoreboard handler hot path and should be cached. Stored by
+# the cache_stats daemon.
+@api.cache.memoize()
 def get_group_scores(gid=None, name=None):
     """
     Get the group scores.

--- a/picoCTF-web/daemons/cache_stats.py
+++ b/picoCTF-web/daemons/cache_stats.py
@@ -31,6 +31,7 @@ def run():
                 api.stats.get_top_teams_score_progressions,
                 gid=group['gid'],
                 eligible=True)
+            cache(api.stats.get_group_scores, gid=group['gid'])
 
         print("Caching number of solves for each problem.")
         for problem in api.problem.get_all_problems():


### PR DESCRIPTION
This is a large performance boot when running a competition with large classrooms/groups.

In a competition with ~600 participants distributed across ~10 groups, this greatly reduces the number of database queries required on a standard `/scoreboard` load. Since the other scoreboard data fetched from `api.stats.get_all_team_scores` is also memoized this does not introduce any additional delay.

Performance testing of query count was largely performed with `mongostat`. Network testing was performed manually in developer tools and we observed a 9 fold reduction in Time to First Byte.