### PR TITLE
Fixing Ansible warnings

### DIFF
--- a/ansible/roles/common/tasks/utils.yml
+++ b/ansible/roles/common/tasks/utils.yml
@@ -8,18 +8,17 @@
 
 - name: Install base packages
   apt:
-    pkg: "{{ item }}"
     state: present
-  with_items:
-    - aptitude          # required for apt module
-    - curl
-    - git
-    - python-passlib    # required for htpasswd module
-    - tmux
-    - vim-nox
-    # monitoring tools
-    - htop
-    - iftop
-    - ncdu
-    - nethogs
-    - vnstat
+    pkg: [
+        'aptitude',         # required for apt module
+        'curl',
+        'git',
+        'python-passlib',   # required for htpasswd module
+        'tmux',
+        'vim-nox',
+        # monitoring tools
+        'htop',
+        'iftop',
+        'ncdu',
+        'nethogs',
+        'vnstat']

--- a/ansible/roles/mongodb/tasks/install.yml
+++ b/ansible/roles/mongodb/tasks/install.yml
@@ -18,10 +18,8 @@
 
 - name: Install mongo
   apt:
-    name: "{{ item }}"
+    name: ['mongodb-org']  # from PPA
     state: present
-  with_items:
-    - mongodb-org     # from PPA
 
 - name: Ensure mongodb is running
   service:

--- a/ansible/roles/pico-shell/tasks/dependencies.yml
+++ b/ansible/roles/pico-shell/tasks/dependencies.yml
@@ -9,49 +9,39 @@
 # Extracted from picoCTF-platform/scripts/shell_setup.sh
 - name: Install picoCTF-shell system dependencies
   apt:
-    name: "{{ item }}"
     state: present
-  with_items:
-    - software-properties-common
-    - xinetd
-    - dpkg
-    - dpkg-dev
-    - fakeroot
-    - python-virtualenv
-    - python-pip      # used for pam module dependencies
-    - python3         # used by shell_manager
-    - python3-pip     # used for shell_manager dependencies
-    - python3.6       # from PPA, to cover all likely interpreter directives
-    - python3.6-dev
-    - python3.6-venv
-    - libffi-dev
-    - libssl-dev
-    - socat
-    - php7.0-cli      # php5 package deprecated
-    - php7.0-sqlite3
-    - gcc-multilib
-    - nginx           # used to serve shellinabox and challenge binaries
-    - shellinabox
+    name: [
+      'software-properties-common',
+      'xinetd',
+      'dpkg',
+      'dpkg-dev',
+      'fakeroot',
+      'python-virtualenv',
+      'python-pip',       # used for pam module dependencies
+      'python3',          # used by shell_manager
+      'python3-pip',      # used for shell_manager dependencies
+      'python3.6',        # from PPA, to cover all likely interpreter directives
+      'python3.6-dev',
+      'python3.6-venv',
+      'libffi-dev',
+      'libssl-dev',
+      'socat',
+      'php7.0-cli',       # php5 package deprecated
+      'php7.0-sqlite3',   # used to serve shellinabox and challenge binaries
+      'gcc-multilib',
+      'nginx',
+      'shellinabox']
 
 # Needed by templated challenge types
 - name: Install uwsgi and plugins for shell server
   apt:
-    name: "{{ item }}"
+    name: ['uwsgi', 'uwsgi-plugin-php', 'uwsgi-plugin-python3', 'uwsgi-plugin-python', 'python-flask']
     state: present
-  with_items:
-    - uwsgi
-    - uwsgi-plugin-php
-    - uwsgi-plugin-python3
-    - uwsgi-plugin-python
-    - python-flask
 
 - name: Install pam dependencies
   apt:
-    name: "{{ item }}"
+    name: ['libpam-python', 'python-setuptools']
     state: present
-  with_items:
-    - libpam-python
-    - python-setuptools
 
 # System python packages updates needed for pam_auth module and Ansible
 - name: Update pyOpenSSL
@@ -93,56 +83,55 @@
 
 - name: Install common apt packages for CTF shell servers
   apt:
-    name: "{{ item }}"
     state: present
-  with_items:
-  # archive tools
-    - bzip2
-    - gzip
-    - tar
-    - unzip
-    - zip
-  # build tools
-    - build-essential
-    - gdb
-    - nasm
-    - perl
-    - python
-    - python3
-    - ruby
-  # common command line tools
-    - dos2unix
-    - gawk
-    - grep
-    - jq
-    - realpath
-    - sed
-    - silversearcher-ag
-  # editors
-    - bvi
-    - emacs-nox
-    - joe
-    - nano
-    - tweak
-    - vim-nox
-  # forensics tools
-    - foremost
-    - scalpel
-    - sleuthkit
-    - testdisk
-    - tshark
-  # networking tools
-    - curl
-    - netcat-openbsd
-    - socat
-    - traceroute
-    - wget
-  # terminal multiplexers
-    - screen
-    - tmux
-  # z: misc
-    - expect
-    - pandoc # for `pip install pwntools`
+    name: [
+      # archive tools
+      'bzip2',
+      'gzip',
+      'tar',
+      'unzip',
+      'zip',
+      # build tools
+      'build-essential',
+      'gdb',
+      'nasm',
+      'perl',
+      'python',
+      'python3',
+      'ruby',
+      # common command line tools
+      'dos2unix',
+      'gawk',
+      'grep',
+      'jq',
+      'realpath',
+      'sed',
+      'silversearcher-ag',
+      # editors
+      'bvi',
+      'emacs-nox',
+      'joe',
+      'nano',
+      'tweak',
+      'vim-nox',
+      # forensics tools
+      'foremost',
+      'scalpel',
+      'sleuthkit',
+      'testdisk',
+      'tshark',
+      # networking tools
+      'curl',
+      'netcat-openbsd',
+      'socat',
+      'traceroute',
+      'wget',
+      # terminal multiplexers
+      'screen',
+      'tmux',
+      # z: misc
+      'expect',
+      'pandoc'] # for `pip install pwntools`
 
 - name: Ensure nano is the default editor
   alternatives:
@@ -150,19 +139,11 @@
     path: /bin/nano
 
 - name: Install common pip2 packages for CTF shell servers
-  pip:
-    name: "{{ item }}"
-  with_items:
-    - ipython<6.0 # 6.0 dropped support for Python2
-    - ptpython
-    - pwntools
+  pip:    # ipython 6.0 dropped support for Python2
+    name: ['ipython<6.0', 'ptpython', 'pwntools']
 
 - name: Install common pip3 packages for CTF shell servers
   pip:
-    name: "{{ item }}"
+    name: ['ipython', 'ptpython', 'pwntools']
     executable: pip3
-  with_items:
-    - ipython
-    - ptpython
-    - pwntools
   when: False # pwntools is not ready for python3; skipping to avoid confusion

--- a/ansible/roles/pico-shell/tasks/deploy_problems.yml
+++ b/ansible/roles/pico-shell/tasks/deploy_problems.yml
@@ -46,11 +46,15 @@
 
 - name: Change /tmp permission
   become: true
-  command: "chmod 1773 /tmp"
+  file:
+    path: /tmp
+    mode: 1773
 
 - name: Change /etc/xinetd.d permission
   become: true
-  command: "chmod 750 /etc/xinetd.d"
+  file:
+    path: /etc/xinetd.d
+    mode: 750
 
 # generally a good idea (on remote, we will find dist.bundle)
 - name: Exclude group and others from ansible_user home directory

--- a/ansible/roles/pico-web/tasks/dependencies.yml
+++ b/ansible/roles/pico-web/tasks/dependencies.yml
@@ -9,19 +9,8 @@
 # Extracted from picoCTF-platform/scripts/web_setup.sh
 - name: Install picoCTF platform system dependencies
   apt:
-    name: "{{ item }}"
+    name: ['python3-pip', 'python3.6', 'python3.6-dev', 'python3.6-venv', 'python-virtualenv', 'gunicorn', 'jekyll', 'nginx', 'libffi-dev', 'libssl-dev']
     state: present
-  with_items:
-    - python3-pip
-    - python3.6
-    - python3.6-dev
-    - python3.6-venv
-    - python-virtualenv
-    - gunicorn
-    - jekyll
-    - nginx
-    - libffi-dev
-    - libssl-dev
 
 - name: Install pymongo in (new) virtualenv
   pip:

--- a/ansible/roles/pico-web/tasks/nodejs.yml
+++ b/ansible/roles/pico-web/tasks/nodejs.yml
@@ -28,11 +28,8 @@
 
 - name: Install nodejs and dependencies
   apt:
-    name: "{{ item }}"
+    name: ['nodejs', 'build-essential']
     state: latest
-  with_items:
-    - nodejs
-    - build-essential
 
 # Extracted from picoCTF-platform/scripts/web_setup.sh
 - name: Install nodejs packages (globally)


### PR DESCRIPTION
Small Ansible refactoring to remove annoying warnings, and fix deprecated code.
Warning examples are shown bellow :)


TASK [pico-shell : Install picoCTF-shell system dependencies] ******************
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items
and specifying `name: "{{ item }}"`, please use `name: ['software-properties-common', 'xinetd', 'dpkg', 'dpkg-dev', 'fakeroot', 'python-virtualenv', 'python-pip', 'python3', 'python3-pip', 'python3.6', 'python3.6-dev', 'python3.6-venv', 'libffi-dev', 'libssl-dev', 'socat', 'php7.0-cli', 'php7.0-sqlite3', 'gcc-multilib', 'nginx', 'shellinabox']` and remove the loop.
 This feature will be removed in version 2.11. Deprecation warnings can be
disabled by setting deprecation_warnings=False in ansible.cfg.


TASK [pico-shell : Change /tmp permission] *************************************
 [WARNING]: Consider using the file module with mode rather than running chmod.
If you need to use command because file is insufficient you can add warn=False
to this command task or set command_warnings=False in ansible.cfg to get rid of
this message.