### PR TITLE
Release lock file for dry-run deployments as well

### DIFF
--- a/picoCTF-shell/hacksport/deploy.py
+++ b/picoCTF-shell/hacksport/deploy.py
@@ -933,8 +933,7 @@ def deploy_problems(args, config):
             execute(["service", "xinetd", "restart"], timeout=60)
 
         logger.debug("Releasing lock file %s", lock_file)
-        if not args.dry:
-            os.remove(lock_file)
+        os.remove(lock_file)
 
 
 def remove_instances(path, instance_list):


### PR DESCRIPTION
Based on the removal of the dry-run check when _creating_ the lock file in:

https://github.com/picoCTF/picoCTF/commit/cc43a20df700cba725893c9383081d6cf63a07ed#diff-cc177e30fab3daa3f822ac12152b15fbL601

it seems like the intent was to use the lock file for both dry-run and real deployments.
This, then, resolves #222 by removing it for dry runs as well.