### PR TITLE
Allow direct deployment of problem directories

### DIFF
--- a/picoCTF-shell/hacksport/deploy.py
+++ b/picoCTF-shell/hacksport/deploy.py
@@ -904,7 +904,11 @@ def deploy_problems(args, config):
 
     try:
         for problem_name in problem_names:
-            if args.dry:
+            if isdir(join(get_problem_root(problem_name, absolute=True))):
+                # problem_name is already an installed package
+                deploy_location = join(get_problem_root(problem_name, absolute=True))
+            elif isdir(problem_name) and args.dry:
+                # dry run - avoid installing package
                 deploy_location = problem_name
             elif isdir(problem_name):
                 # problem_name is a source dir - convert to .deb and install
@@ -922,9 +926,6 @@ def deploy_problems(args, config):
                 except subprocess.CalledProcessError:
                     logger.error("An error occurred while installing problem packages.")
                     raise FatalException
-                deploy_location = join(get_problem_root(problem_name, absolute=True))
-            elif isdir(join(get_problem_root(problem_name, absolute=True))):
-                # problem_name is already an installed package
                 deploy_location = join(get_problem_root(problem_name, absolute=True))
             else:
                 logger.error("'%s' is neither an installed package, nor a valid problem directory",

--- a/picoCTF-shell/hacksport/deploy.py
+++ b/picoCTF-shell/hacksport/deploy.py
@@ -111,12 +111,10 @@ import functools
 import json
 import logging
 import os
-import re
 import shutil
 import subprocess
 import traceback
 from abc import ABCMeta
-from argparse import Namespace
 from copy import copy, deepcopy
 from grp import getgrnam
 from hashlib import md5, sha1

--- a/picoCTF-shell/hacksport/deploy.py
+++ b/picoCTF-shell/hacksport/deploy.py
@@ -927,7 +927,7 @@ def deploy_problems(args, config):
                 try:
                     # reinstall flag ensures package will be overwritten if version is the same,
                     # maintaining previous 'dpkg -i' behavior
-                    subprocess.run('apt install --reinstall {}'.format(generated_deb_path), shell=True, check=True, stdout=subprocess.PIPE)
+                    subprocess.run('apt-get install --reinstall {}'.format(generated_deb_path), shell=True, check=True, stdout=subprocess.PIPE)
                 except subprocess.CalledProcessError:
                     logger.error("An error occurred while installing problem packages.")
                     raise FatalException

--- a/picoCTF-shell/shell_manager/package.py
+++ b/picoCTF-shell/shell_manager/package.py
@@ -169,7 +169,8 @@ def package_problem(problem_path, staging_path=None, out_path=None, ignore_files
         ignore_files (list of str, optional): filenames to exclude
             when packaging this problem.
     Returns:
-        str: the absolute path to the packaged problem
+        tuple (str, str): the name of the package,
+            the absolute path to the packaged problem
     """
     problem = get_problem(problem_path)
     logger.debug("Starting to package: '%s'.", problem["name"])
@@ -226,6 +227,7 @@ def package_problem(problem_path, staging_path=None, out_path=None, ignore_files
         logger.error("Error building problem deb for '%s'.",
                         problem["name"])
         logger.error(result.output)
+        raise FatalException
     else:
         logger.info("Problem '%s' packaged successfully.", problem["name"])
 
@@ -234,7 +236,7 @@ def package_problem(problem_path, staging_path=None, out_path=None, ignore_files
                     problem["name"], paths["staging"])
     rmtree(paths["staging"])
 
-    return os.path.abspath(deb_path)
+    return (problem['name'], os.path.abspath(deb_path))
 
 
 def problem_builder(args, config):
@@ -257,4 +259,4 @@ def problem_builder(args, config):
         problem_paths.extend(problems_in_base)
 
     for problem_path in problem_paths:
-        package_problem(problem_path, args.staging_dir, args.out_dir, args.ignore)
+        package_problem(problem_path, args.staging_dir, args.out, args.ignore)

--- a/picoCTF-shell/shell_manager/package.py
+++ b/picoCTF-shell/shell_manager/package.py
@@ -236,7 +236,7 @@ def package_problem(problem_path, staging_path=None, out_path=None, ignore_files
                     problem["name"], paths["staging"])
     rmtree(paths["staging"])
 
-    return (problem['name'], os.path.abspath(deb_path))
+    return (sanitize_name(problem.get("pkg_name", problem["name"])), os.path.abspath(deb_path))
 
 
 def problem_builder(args, config):


### PR DESCRIPTION
Modifies the behavior of the `shell_manager deploy` command.

Previously, only the following syntax was valid:
`shell_manager deploy installed_package_name`
`shell_manager deploy -d problem_source_directory`

Now, any combination works:
```
shell_manager deploy installed-package-name|problem-source-directory
shell_manager deploy -d installed-package-name|problem-source-directory
```

When deploying a source directory (without `-d`), the .deb package is created and installed behind-the-scenes. Also of note, it is installed using `apt-get` rather than `dpkg`, so dependencies should be handled automatically, as mentioned in #111.

Wiki documentation will also need to be updated – I think recommending the use of `shell_manager deploy` directly for typical deployments, and the multi-step `shell_manager package`, `apt-get install`, `shell_manager deploy` process for complex deployments that make use of `shell_manager package`'s additional functionality (e.g. ignored files, nested problem directories) would make sense.

Resolves #54, resolves #111