### PR TITLE
Remove DEFAULT_MODULE_LANG from Ansible config

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,10 +1,6 @@
 
 [defaults]
 
-# necessary to fix unicode errors with pip install
-# should match locale installed for ansible_user
-module_lang    = en_US.UTF-8
-
 # disable checking host keys when using ssh
 # this reduces friction when rapidly creating and destroying environments
 host_key_checking=False


### PR DESCRIPTION
This had been introduced in 73bb331b9af31edbdc5271196249cdd7f95b43ab
to solve an installation issue that is no longer occurring with the current versions of Ansible/spur.

Resolves #261 