### PR TITLE
Clarified flag submission error messages (issue #252)

### DIFF
--- a/picoCTF-web/api/problem.py
+++ b/picoCTF-web/api/problem.py
@@ -444,7 +444,7 @@ def submit_key(tid, pid, key, method, uid=None, ip=None):
 
     if pid in get_solved_pids(tid=tid):
         exp = WebException(
-            "You or one of your teammates have already solved this problem.")
+            "Flag correct: however, you have already received points for that flag.")
         exp.data = {'code': 'solved'}
         raise exp
 
@@ -476,7 +476,7 @@ def submit_key(tid, pid, key, method, uid=None, ip=None):
     if (key, pid) in [(submission["key"], submission["pid"])
                       for submission in get_submissions(tid=tid)]:
         exp = WebException(
-            "You or one of your teammates have already tried this solution.")
+            "Flag incorrect: please note that you or your team have already submitted this flag.")
         exp.data = {'code': 'repeat'}
         raise exp
 


### PR DESCRIPTION
My tactics here for effective communication were Bottom Line Up Front. The first two words of both messages indicate success or failure. The rest of the messages is quite helpful for problem solving, but really just clarification.

@maverickwoo The messages have been standardized according to your request in the closed PR: #257 

Resolves #252 