### PR TITLE
Configure Vagrant choice of more secure NIC's

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,7 +16,7 @@ end
 Vagrant.configure("2") do |config|
   config.vm.define "shell", primary: true do |shell|
     shell.vm.box = "ubuntu/bionic64"
-    shell.vm.network "private_network", ip: (ENV['SIP'] || '192.168.2.3')
+    shell.vm.network "private_network", ip: (ENV['SIP'] || '192.168.2.3'), nic_type: "virtio"
 
     shell.vm.synced_folder ".", "/vagrant", disabled: true
     shell.vm.synced_folder ".", "/picoCTF",
@@ -55,7 +55,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "web", primary: true do |web|
     web.vm.box = "ubuntu/bionic64"
-    web.vm.network "private_network", ip: (ENV['WIP'] || '192.168.2.2')
+    web.vm.network "private_network", ip: (ENV['WIP'] || '192.168.2.2'), nic_type: "virtio"
 
     web.vm.synced_folder ".", "/vagrant", disabled: true
     web.vm.synced_folder ".", "/picoCTF",

--- a/vagrant/build_base_boxes/Vagrantfile
+++ b/vagrant/build_base_boxes/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure("2") do |config|
     # Vanilla debian base box from: https://atlas.hashicorp.com/debian/
     # includes vboxsf module for synchronization
     shell.vm.box = "debian/contrib-jessie64"
-    shell.vm.network "private_network", ip: "192.168.2.3"
+    shell.vm.network "private_network", ip: "192.168.2.3", nic_type: "virtio"
 
     # Only since this is a base box.
     shell.ssh.insert_key = false
@@ -38,7 +38,7 @@ Vagrant.configure("2") do |config|
   config.vm.define "web", primary: true do |web|
     
     web.vm.box = "debian/contrib-jessie64"
-    web.vm.network "private_network", ip: "192.168.2.2"
+    web.vm.network "private_network", ip: "192.168.2.2", nic_type: "virtio"
 
     # Only since this is a base box.
     web.ssh.insert_key = false

--- a/vagrant/local_testing/Vagrantfile
+++ b/vagrant/local_testing/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure("2") do |config|
     # Could be changed to a completely fresh base with:
     # db.vm.box = "debian/contrib-jessie64"
     db.vm.box = "picoCTF/web-base"
-    db.vm.network "private_network", ip: "10.0.5.20"
+    db.vm.network "private_network", ip: "10.0.5.20", nic_type: "virtio"
     # Disable synced folder to simulate remote environment
     db.vm.synced_folder ".", "/vagrant", disabled: true
     db.vm.provider "virtualbox" do |vb|
@@ -19,7 +19,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "shell", primary: true do |shell|
     shell.vm.box = "picoCTF/shell-base"
-    shell.vm.network "private_network", ip: "10.0.5.11"
+    shell.vm.network "private_network", ip: "10.0.5.11", nic_type: "virtio"
     shell.vm.synced_folder ".", "/vagrant", disabled: true
     shell.vm.provider "virtualbox" do |vb|
         vb.name = "picoCTF-shell-testing"
@@ -29,7 +29,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "web", primary: true do |web|
     web.vm.box = "picoCTF/web-base"
-    web.vm.network "private_network", ip: "10.0.5.10"
+    web.vm.network "private_network", ip: "10.0.5.10", nic_type: "virtio"
     web.vm.synced_folder ".", "/vagrant", disabled: true
     web.vm.provider "virtualbox" do |vb|
         vb.name = "picoCTF-web-testing"


### PR DESCRIPTION
This pull-request forces Vagrant to use a network interface card (NIC) we choose, recommended by a built-in warning, as documented in #244. We chose "virtio" to mandate as NIC to the configured networks.

My testing steps were as follows:
- $ vagrant destroy
- $ vagrant up
   - It should be noted here that no provisioning steps had any ominous security warnings as seen in the issue #244 
- *register user at local pico web portal*
- *submit incorrect flag*
- *submit correct flag*

All these steps worked as expected. I also manually inspected the NIC's reported by Virtualbox and found them as expected.

As raised in a related PR #257, all Vagrantfiles in the project were inspected and all mentions of network have been amended with a mandatory NIC "virtio".

Resolves #244 