### PR TITLE
Rework eligibility

### DIFF
--- a/picoCTF-web/api/config.py
+++ b/picoCTF-web/api/config.py
@@ -163,6 +163,13 @@ default_settings = {
         "default_stepping": 5000,
         "steps": [7500, 12500, 17500],
         "limit_added_range": False,
+    },
+
+    # ELIGIBILITY CONDITIONS
+    # (user properties)
+    "eligibility": {
+        "usertype": "student",
+        "country": "US"
     }
 }
 """ Helper functions to get settings. Do not change these """

--- a/picoCTF-web/api/problem.py
+++ b/picoCTF-web/api/problem.py
@@ -458,8 +458,6 @@ def submit_key(tid, pid, key, method, uid=None, ip=None):
 
     problem = get_problem(pid=pid)
 
-    eligibility = api.team.get_team(tid=tid)['eligible']
-
     submission = {
         'uid': uid,
         'tid': tid,
@@ -468,7 +466,6 @@ def submit_key(tid, pid, key, method, uid=None, ip=None):
         'ip': ip,
         'key': key,
         'method': method,
-        'eligible': eligibility,
         'category': problem['category'],
         'correct': result['correct'],
     }
@@ -507,7 +504,7 @@ def count_submissions(pid=None,
                       tid=None,
                       category=None,
                       correctness=None,
-                      eligibility=None):
+                      ):
     db = api.common.get_conn()
     match = {}
     if uid is not None:
@@ -524,9 +521,6 @@ def count_submissions(pid=None,
     if correctness is not None:
         match.update({"correct": correctness})
 
-    if eligibility is not None:
-        match.update({"eligible": eligibility})
-
     return db.submissions.find(match, {"_id": 0}).count()
 
 
@@ -535,7 +529,7 @@ def get_submissions(pid=None,
                     tid=None,
                     category=None,
                     correctness=None,
-                    eligibility=None):
+                    ):
     """
     Gets the submissions from a team or user.
     Optional filters of pid or category.
@@ -568,9 +562,6 @@ def get_submissions(pid=None,
 
     if correctness is not None:
         match.update({"correct": correctness})
-
-    if eligibility is not None:
-        match.update({"eligible": eligibility})
 
     return list(db.submissions.find(match, {"_id": 0}))
 

--- a/picoCTF-web/api/routes/stats.py
+++ b/picoCTF-web/api/routes/stats.py
@@ -57,7 +57,7 @@ def get_scoreboard_hook(board, page):
     # Old board, limit 1-50
     if board is None:
         result = {'tid': 0, 'groups': []}
-        global_board = api.stats.get_all_team_scores(eligible=True, country=None, show_ineligible=True)
+        global_board = api.stats.get_all_team_scores(include_ineligible=True)
         result['global'] = {
             'name': 'global',
             'pages': math.ceil(len(global_board) / scoreboard_page_len),
@@ -73,7 +73,7 @@ def get_scoreboard_hook(board, page):
             result['global']['start_page'] = math.ceil((global_pos + 1) / 50)
 
             result['country'] = user["country"]
-            student_board = api.stats.get_all_team_scores(eligible=True, country=None, show_ineligible=False)
+            student_board = api.stats.get_all_team_scores()
             student_pos = get_user_pos(student_board, user["tid"])
             start_slice = math.floor(student_pos / 50) * 50
             result['student'] = {
@@ -121,9 +121,9 @@ def get_scoreboard_hook(board, page):
                             group_board[start:end]
                     })
             elif board == "global":
-                result = api.stats.get_all_team_scores(eligible=True, country=None, show_ineligible=True)[start:end]
+                result = api.stats.get_all_team_scores(include_ineligible=True)[start:end]
             elif board == "student":
-                result = api.stats.get_all_team_scores(eligible=True, country=None, show_ineligible=False)[start:end]
+                result = api.stats.get_all_team_scores()[start:end]
             else:
                 result = []
             return WebSuccess(data=result)
@@ -134,20 +134,12 @@ def get_scoreboard_hook(board, page):
 @blueprint.route('/top_teams/score_progression', methods=['GET'])
 @api_wrapper
 def get_top_teams_score_progressions_hook():
-    eligible = request.args.get("eligible", "true")
-    eligible = bson.json_util.loads(eligible)
-
-    show_ineligible = request.args.get("show_ineligible", "false")
-    show_ineligible = bson.json_util.loads(show_ineligible)
-
-    country = None
-    # if api.auth.is_logged_in():
-    #    user = api.user.get_user()
-    #    if user["country"] in ["US"] and not show_ineligible:
-    #        country = user["country"]
+    include_ineligible = request.args.get("include_ineligible", "false")
+    include_ineligible = bson.json_util.loads(include_ineligible)
 
     return WebSuccess(
-        data=api.stats.get_top_teams_score_progressions(eligible=eligible, country=country, show_ineligible=show_ineligible))
+        data=api.stats.get_top_teams_score_progressions(
+            include_ineligible=include_ineligible))
 
 
 @blueprint.route('/group/score_progression', methods=['GET'])
@@ -155,7 +147,7 @@ def get_top_teams_score_progressions_hook():
 def get_group_top_teams_score_progressions_hook():
     gid = request.args.get("gid", None)
     return WebSuccess(
-        data=api.stats.get_top_teams_score_progressions(gid=gid, show_ineligible=True))
+        data=api.stats.get_top_teams_score_progressions(gid=gid, include_ineligible=True))
 
 
 @blueprint.route('/registration', methods=['GET'])

--- a/picoCTF-web/api/shell_servers.py
+++ b/picoCTF-web/api/shell_servers.py
@@ -356,7 +356,7 @@ def reassign_teams(include_assigned=False):
     db = api.common.get_conn()
 
     if include_assigned:
-        teams = api.team.get_all_teams(show_ineligible=True)
+        teams = api.team.get_all_teams(include_ineligible=True)
     else:
         teams = list(
             db.teams.find({

--- a/picoCTF-web/api/team.py
+++ b/picoCTF-web/api/team.py
@@ -164,7 +164,6 @@ def create_new_team_request(params, uid=None):
         "team_name": params["team_name"],
         "password": api.common.hash_password(params["team_password"]),
         "affiliation": current_team["affiliation"],
-        "eligible": user["eligible"],
         "creator": user["uid"],
         "country": user["country"],
     })
@@ -180,7 +179,6 @@ def create_team(params):
         team_name: Name of the team
         school: Name of the school
         password: Team's hashed password
-        eligible: the teams eligibility, inherited from creator
         country: primary country of team
         creator: uid of creating user
     Returns:
@@ -230,7 +228,6 @@ def get_team_members(tid=None, name=None, show_disabled=True):
             "teacher": 1,
             "country": 1,
             "usertype": 1,
-            "eligible": 1,
         }))
     return [
         user for user in users
@@ -303,35 +300,53 @@ def get_team_information(tid=None, gid=None):
         solved_problem.pop("pkg_dependencies", None)
         team_info["solved_problems"].append(solved_problem)
 
+    team_info["eligible"] = is_eligible(tid)
+
     return team_info
 
 
-def get_all_teams(ineligible=False, eligible=True, country=None, show_ineligible=False):
+def is_eligible(tid):
     """
-    Retrieves all teams.
+    Return a team's eligibility for the current event.
+
+    Args:
+        tid: the team id
+    Returns:
+        True or False
+    """
+    members = get_team_members(tid)
+    conditions = api.config.get_settings()['eligibility']
+    for member in members:
+        is_eligible = all(
+            (member[k] == conditions[k] for k in conditions.keys()))
+        if not is_eligible:
+            return False
+    return True
+
+
+def get_all_teams(include_ineligible=False, country=None):
+    """
+    Retrieve all teams.
+
+    Args:
+        include_ineligible: include ineligible teams in result
 
     Returns:
         A list of all of the teams.
+
     """
-
-    if show_ineligible:
-        match = {}
-    else:
-        conditions = []
-        if ineligible:
-            conditions.append({"eligible": False})
-        elif eligible:
-            conditions.append({"eligible": True})
-        match = {"$or": conditions}
-
+    # Ignore empty teams (remnants of single player self-team ids)
+    match = {"size": {"$gt": 0}}
     if country is not None:
         match.update({"country": country})
 
-    # Ignore empty teams (remnants of single player self-team ids)
-    match.update({"size": {"$gt": 0}})
-
     db = api.common.get_conn()
-    return list(db.teams.find(match, {"_id": 0}))
+    teams = list(db.teams.find(match, {"_id": 0}))
+
+    # Filter out ineligible teams, if desired
+    if not include_ineligible:
+        teams = [t for t in teams if is_eligible(t['tid'])]
+    return teams
 
 
 def join_team_request(params):
@@ -413,14 +428,10 @@ def join_team(team_name, password, uid=None):
             }},
             new=True)
 
-        # Team country is no longer consistent amongst members. Flag as mixed and ineligible
+        # Team country is no longer consistent amongst members - set as mixed
         if user["country"] != desired_team["country"]:
             db.teams.update({"tid": desired_team["tid"]}, {"$set": {"country": "??",
-                                                                    "eligible": False}})
-
-        # Ineligible user has spoiled team eligibility
-        if not user["eligible"] and desired_team["eligible"]:
-            db.teams.update({"tid": desired_team["tid"]}, {"$set": {"eligible": False}})
+                                                                    }})
 
         if not desired_team_size_update or not current_team_size_update:
             raise InternalException(

--- a/picoCTF-web/api/user.py
+++ b/picoCTF-web/api/user.py
@@ -192,7 +192,6 @@ def create_user(username,
                 usertype,
                 country,
                 demo,
-                eligible,
                 teacher=False,
                 admin=False,
                 verified=False):
@@ -210,7 +209,6 @@ def create_user(username,
         country: primary country (dependent on usertype)
         demo: dict of demographic data
         teacher: whether this account is a teacher
-        eligible: whether this account is eligible for prizes (or at least, not ineligible)
     Returns:
         Returns the uid of the newly created user
     """
@@ -257,7 +255,6 @@ def create_user(username,
         'demo': demo,
         'teacher': teacher,
         'admin': admin,
-        'eligible': eligible,
         'disabled': False,
         'verified': not settings["email"]["email_verification"] or verified,
         'extdata': {},
@@ -332,7 +329,6 @@ def create_simple_user_request(params):
             firstname: user's first name
             lastname: user's first name
             email: user's email
-            eligibility: True or False
             country: 2-digit country code
             affiliation: user's affiliation
             usertype: "student", "teacher" or other
@@ -340,8 +336,6 @@ def create_simple_user_request(params):
             gid: group registration
             rid: registration id
     """
-
-    params["eligibility"] = params["usertype"] == "student"
 
     validate(user_schema, params)
 
@@ -391,7 +385,6 @@ def create_simple_user_request(params):
     team_params = {
         "team_name": params["username"],
         "password": api.common.token(),
-        "eligible": params["eligibility"],
         "affiliation": params["affiliation"],
         "country": params["country"]
     }
@@ -413,7 +406,6 @@ def create_simple_user_request(params):
         params["usertype"],
         params["country"],
         params["demo"],
-        params["eligibility"],
         teacher=user_is_teacher,
         verified=user_was_invited)
 

--- a/picoCTF-web/daemons/cache_stats.py
+++ b/picoCTF-web/daemons/cache_stats.py
@@ -16,19 +16,18 @@ def run():
     cache(api.stats.get_registration_count)
 
     print("Caching the public scoreboard entries...")
-    cache(api.stats.get_all_team_scores, eligible=True, country=None, show_ineligible=False)
-    cache(api.stats.get_all_team_scores, eligible=True, country=None, show_ineligible=True)
+    cache(api.stats.get_all_team_scores)
+    cache(api.stats.get_all_team_scores, include_ineligible=True)
 
     print("Caching the public scoreboard graph...")
-    cache(api.stats.get_top_teams_score_progressions, eligible=True, country=None, show_ineligible=False)
-    cache(api.stats.get_top_teams_score_progressions, eligible=True, country=None, show_ineligible=True)
+    cache(api.stats.get_top_teams_score_progressions)
+    cache(api.stats.get_top_teams_score_progressions, include_ineligible=True)
 
     print("Caching the scoreboard graph for each group...")
     for group in api.group.get_all_groups():
         cache(
             api.stats.get_top_teams_score_progressions,
-            gid=group['gid'],
-            show_ineligible=True)
+            gid=group['gid'])
         cache(api.stats.get_group_scores, gid=group['gid'])
 
     print("Caching number of solves for each problem.")

--- a/picoCTF-web/daemons/share_instances.py
+++ b/picoCTF-web/daemons/share_instances.py
@@ -89,7 +89,7 @@ def run():
     global connections
 
     if api.utilities.check_competition_active():
-        teams = api.team.get_all_teams(show_ineligible=True)
+        teams = api.team.get_all_teams(include_ineligible=True)
 
         for server in api.shell_servers.get_servers(get_all=True):
             try:

--- a/picoCTF-web/web/coffee/progression_graphs.coffee
+++ b/picoCTF-web/web/coffee/progression_graphs.coffee
@@ -149,7 +149,7 @@ progressionDataToPoints = (data, dataPoints, currentDate = 0) ->
     apiCall "GET", "/api/stats/top_teams/score_progression", {}
     .done drawgraph
   else if gid == "global"
-    apiCall "GET", "/api/stats/top_teams/score_progression", {show_ineligible: true}
+    apiCall "GET", "/api/stats/top_teams/score_progression", {include_ineligible: true}
     .done drawgraph
   else
     apiCall "GET", "/api/stats/group/score_progression", {gid:gid}


### PR DESCRIPTION
- Team eligibility is computed as-needed
- Eligibility requirements are a configuration setting (long term, these could be per-event and have a richer DSL for e.g. age comparisons)
- "eligible", "ineligible", and "show_ineligible" parameters reworked into
  the "include_ineligible" parameter (defaults to False)

I tested that the on-demand eligibility calculation seems to be working for 1-person teams (looking at the `/api/team` output for various accounts). I couldn't figure out how to test adding users to a different team - is that functionality broken/disabled somewhere in this repo?