### PR TITLE
Added ansible task to disable inter-user communication by default

### DIFF
--- a/ansible/roles/pico-shell/tasks/main.yml
+++ b/ansible/roles/pico-shell/tasks/main.yml
@@ -35,6 +35,11 @@
     group: root
     mode: 0755
 
+- name: Disable inter-user messages by default
+  lineinfile:
+    path: /etc/profile
+    line: mesg n
+
 # Missing
 # journald
 # services


### PR DESCRIPTION
In the past, the program "wall" would enable any competitor to broadcast a message to the terminals of all other shell server users. There are other such programs for "inter-user" communication on an Ubuntu box, but "wall" is esp. powerful. The solution I decided on, proposed by @maverickwoo in #205 , was to disable the reception of other users' messages by default by appending "mesg n" to the end of "/etc/profile". This protects shell server users from possible spam.

Testing this change:
From a fresh "vagrant up" I verified that the "mesg n" line was at the end of "/etc/profile". I verified that after my change, a normal user did not receive messages from other users.

Resolves #280 