### PR TITLE
Resolve jinja2 vulnerability

### DIFF
--- a/picoCTF-shell/setup.py
+++ b/picoCTF-shell/setup.py
@@ -77,7 +77,7 @@ setup(
     install_requires=[
         'coloredlogs==10.0',
         'Flask==1.0.2',
-        'Jinja2==2.10',
+        'Jinja2==2.10.1',
         'openssh-wrapper==0.4',
         'psutil==5.4.6',
         'pytest==3.6.1',


### PR DESCRIPTION
To fix https://nvd.nist.gov/vuln/detail/CVE-2019-10906

Confirmed web server still comes up, seems to work fine with new version.