### PR TITLE
Allow regrading of solved problems

### DIFF
--- a/picoCTF-web/api/logger.py
+++ b/picoCTF-web/api/logger.py
@@ -64,7 +64,7 @@ class StatsHandler(logging.StreamHandler):
                 "pid": pid,
                 "key": key,
                 "method": method,
-                "success": result["correct"]
+                "success": result[0]
             },
         "api.problem_feedback.add_problem_feedback":
             lambda pid, uid, feedback, result=None: {

--- a/picoCTF-web/api/routes/problem.py
+++ b/picoCTF-web/api/routes/problem.py
@@ -79,12 +79,23 @@ def submit_key_hook():
     method = request.form.get('method', '')
     ip = request.remote_addr
 
-    result = api.problem.submit_key(tid, pid, key, method, uid, ip)
+    correct, previously_solved = api.problem.submit_key(
+        tid, pid, key, method, uid, ip)
 
-    if result['correct']:
-        return WebSuccess(result['message'], result['points'])
-    else:
-        return WebError(result['message'], {'code': 'wrong'})
+    if correct and not previously_solved:
+        return WebSuccess("That is correct!")
+    elif not correct and not previously_solved:
+        return WebError("That is incorrect!")
+    elif correct and previously_solved:
+        return WebSuccess(
+            'Flag correct: however, you have already received points ' +
+            'for that flag.'
+        )
+    elif not correct and previously_solved:
+        return WebError(
+            'Flag incorrect: please note that you or your team have ' +
+            'already solved this problem.'
+        )
 
 
 @blueprint.route('/<path:pid>', methods=['GET'])

--- a/picoCTF-web/api/routes/problem.py
+++ b/picoCTF-web/api/routes/problem.py
@@ -79,21 +79,32 @@ def submit_key_hook():
     method = request.form.get('method', '')
     ip = request.remote_addr
 
-    correct, previously_solved = api.problem.submit_key(
-        tid, pid, key, method, uid, ip)
+    (correct, previously_solved_by_user,
+     previously_solved_by_team) = api.problem.submit_key(
+            tid, pid, key, method, uid, ip)
 
-    if correct and not previously_solved:
+    if correct and not previously_solved_by_team:
         return WebSuccess("That is correct!")
-    elif not correct and not previously_solved:
+    elif not correct and not previously_solved_by_team:
         return WebError("That is incorrect!")
-    elif correct and previously_solved:
+    elif correct and previously_solved_by_user:
         return WebSuccess(
-            'Flag correct: however, you have already received points ' +
-            'for that flag.'
+            'Flag correct: however, you have already solved ' +
+            'this problem.'
         )
-    elif not correct and previously_solved:
+    elif correct and previously_solved_by_team:
+        return WebSuccess(
+            'Flag correct: however, your team has already received points ' +
+            'for this flag.'
+        )
+    elif not correct and previously_solved_by_user:
         return WebError(
-            'Flag incorrect: please note that you or your team have ' +
+            'Flag incorrect: please note that you have ' +
+            'already solved this problem.'
+        )
+    elif not correct and previously_solved_by_team:
+        return WebError(
+            'Flag incorrect: please note that someone on your team has ' +
             'already solved this problem.'
         )
 

--- a/picoCTF-web/api/stats.py
+++ b/picoCTF-web/api/stats.py
@@ -654,7 +654,7 @@ def check_invalid_instance_submissions(gid=None):
                 # make sure that the key is still invalid
                 if not api.problem.grade_problem(
                         submission['pid'], submission['key'],
-                        tid=submission['tid'])['correct']:
+                        tid=submission['tid']):
                     if group is None or submission['tid'] in group['members']:
                         submission['username'] = api.user.get_user(
                             uid=submission['uid'])['username']


### PR DESCRIPTION
Previous behavior (did not actually verify submitted flag if the team had already solved the problem):

| previously submitted? | correct? | message displayed |
| --- | --- | --- |
| N | N | (error) "That is incorrect!" |
| N | Y | (success) "That is correct!" |
| Y | N | (error) "Flag correct: however, you have already received points for that flag." |
| Y | Y | (error) "Flag correct: however, you have already received points for that flag." |

New behavior:

| previously submitted? | correct? | message displayed |
| --- | --- | --- |
| N | N | (error) "That is incorrect!" |
| N | Y | (success) "That is correct!" |
| Y | N | (error) "Flag incorrect: please note that you or your team have  already solved this problem." |
| Y | Y | (success) "Flag correct: however, you have already received points for that flag." |

#215 notes that we may want to consider storing submissions after a team's first correct submission in the database. I've (tentatively) decided not to do that because it seems like it could make the correct/incorrect submissions breakdown in the admin view less meaningful, though this could easily be changed.

resolves #215 