### PR TITLE
Small shell manager code cleanups

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,7 +1,7 @@
 [settings]
 known_first_party=sqlalchemy_utils
 line_length=80
-multi_line_output=3
+multi_line_output=0
 not_skip=__init__.py
 order_by_type=false
 skip=picoCTF-web/api/__init__.py

--- a/picoCTF-shell/shell_manager/bundle.py
+++ b/picoCTF-shell/shell_manager/bundle.py
@@ -7,7 +7,7 @@ import json
 import logging
 import os
 from os import chmod, getcwd, makedirs
-from os.path import basename, dirname, isdir, join
+from os.path import dirname, isdir, join
 from shutil import copyfile, rmtree
 
 import spur

--- a/picoCTF-shell/shell_manager/config.py
+++ b/picoCTF-shell/shell_manager/config.py
@@ -73,7 +73,7 @@ def set_configuration_option(args, global_config):
     if args.json:
         try:
             value = json.loads(args.value)
-        except Exception as e:
+        except Exception:
             logger.fatal("Couldn't parse value as JSON")
             raise FatalException
 
@@ -94,7 +94,7 @@ def set_configuration_option(args, global_config):
     else:
         write_global_configuration(config)
 
-    logger.info("Set {} = {}".format(field, value))
+    logger.info("Set %s = %s", field, value)
 
 
 def new_configuration_file(args, global_config):

--- a/picoCTF-shell/shell_manager/package.py
+++ b/picoCTF-shell/shell_manager/package.py
@@ -2,14 +2,11 @@
 Packaging operations for the shell manager.
 """
 
-import gzip
-import json
 import logging
 import os
-import re
 from copy import deepcopy
-from os import chmod, getcwd, listdir, makedirs
-from os.path import dirname, isdir, isfile, join
+from os import chmod, getcwd, makedirs
+from os.path import isdir, isfile, join
 from shutil import copy, rmtree
 
 import spur

--- a/picoCTF-shell/shell_manager/package.py
+++ b/picoCTF-shell/shell_manager/package.py
@@ -26,7 +26,7 @@ DEB_DEFAULTS = {
 
 def problem_to_control(problem, debian_path):
     """
-    Convert problem.json to a deb control file.
+    Converts problem.json to a deb control file.
 
     Args:
         problem: deserialized problem.json (dict)
@@ -44,7 +44,7 @@ def problem_to_control(problem, debian_path):
             "Architecture": problem.get("architecture", "all"),
             "Maintainer": problem["author"],
             "Description": problem.get("pkg_description", problem[
-                "description"].replace('\n', '')) # replace the new lines to prevent a crash
+                "description"].replace('\n', ''))  # replace the new lines to prevent a crash
         })
 
     if "pkg_dependencies" in problem:
@@ -139,7 +139,8 @@ def postinst_dependencies(problem, problem_path, debian_path, install_path):
 def find_problems(problem_path):
     """
     Find all problems that exist under the given root.
-    We consider any directory with a problem.json to be an intended problem directory.
+    We consider any directory with a problem.json to be an intended problem
+    directory.
 
     Args:
         problem_path: the problem directory
@@ -182,8 +183,7 @@ def package_problem(problem_path, staging_path=None, out_path=None, ignore_files
     else:
         paths["staging"] = join(staging_path, "__staging")
     paths["debian"] = join(paths["staging"], "DEBIAN")
-    paths["data"] = join(paths["staging"],
-                         get_problem_root(problem["name"]))
+    paths["data"] = join(paths["staging"], get_problem_root(problem["name"]))
     paths["install_data"] = join(paths["data"], "__files")
     for path in paths.values():
         if not isdir(path):
@@ -197,7 +197,7 @@ def package_problem(problem_path, staging_path=None, out_path=None, ignore_files
     chmod(paths["data"], 0o750)
     problem_to_control(problem, paths["debian"])
     postinst_dependencies(problem, problem_path, paths["debian"],
-                            paths["install_data"])
+                          paths["install_data"])
 
     # Package the staging directory as a .deb
     def format_deb_file_name(problem):
@@ -208,7 +208,7 @@ def package_problem(problem_path, staging_path=None, out_path=None, ignore_files
             problem: the problem object
 
         Returns:
-        An acceptable file name for the problem.
+            An acceptable file name for the problem.
         """
 
         raw_package_name = "{}-{}-{}.deb".format(
@@ -224,19 +224,19 @@ def package_problem(problem_path, staging_path=None, out_path=None, ignore_files
     result = shell.run(
         ["fakeroot", "dpkg-deb", "--build", paths["staging"], deb_path])
     if result.return_code != 0:
-        logger.error("Error building problem deb for '%s'.",
-                        problem["name"])
+        logger.error("Error building problem deb for '%s'.", problem["name"])
         logger.error(result.output)
         raise FatalException
     else:
         logger.info("Problem '%s' packaged successfully.", problem["name"])
 
     # Remove the staging directory
-    logger.debug("Cleaning up '%s' staging directory '%s'.",
-                    problem["name"], paths["staging"])
+    logger.debug("Cleaning up '%s' staging directory '%s'.", problem["name"],
+                 paths["staging"])
     rmtree(paths["staging"])
 
-    return (sanitize_name(problem.get("pkg_name", problem["name"])), os.path.abspath(deb_path))
+    return (sanitize_name(problem.get("pkg_name", problem["name"])),
+            os.path.abspath(deb_path))
 
 
 def problem_builder(args, config):

--- a/picoCTF-shell/shell_manager/problem_repo.py
+++ b/picoCTF-shell/shell_manager/problem_repo.py
@@ -25,7 +25,7 @@ def update_repo(args, config):
         remote_update(args.repository, args.package_paths)
 
 
-def remote_update(repo_ui, deb_paths=None):
+def remote_update(repo_uri, deb_paths=None):
     """
     Pushes packages to a remote deb repository.
 
@@ -46,7 +46,7 @@ def local_update(repo_path, deb_paths=None):
 
     Args:
         repo_path: the path to the local repository.
-        dep_paths: list of problem deb paths to copy.
+        deb_paths: list of problem deb paths to copy.
     """
 
     if deb_paths is None:

--- a/picoCTF-shell/shell_manager/run.py
+++ b/picoCTF-shell/shell_manager/run.py
@@ -3,12 +3,10 @@
 Shell Manager -- Tools for deploying and packaging problems.
 """
 
-import json
 import logging
 from argparse import ArgumentParser
 
 import coloredlogs
-import shell_manager
 from hacksport.deploy import deploy_problems, undeploy_problems
 from hacksport.status import clean, publish, status
 from shell_manager.bundle import bundle_problems

--- a/picoCTF-shell/shell_manager/util.py
+++ b/picoCTF-shell/shell_manager/util.py
@@ -39,7 +39,7 @@ default_config = ConfigDict({
     "deploy_secret":
     "qwertyuiop",
 
-    # the externally accessable address of this server
+    # the externally accessible address of this server
     "hostname":
     "127.0.0.1",
 
@@ -134,7 +134,7 @@ class FatalException(Exception):
 def get_attributes(obj):
     """
     Returns all attributes of an object, excluding those that start with
-    an underscore
+    an underscore.
 
     Args:
         obj: the object
@@ -151,7 +151,7 @@ def get_attributes(obj):
 
 def sanitize_name(name):
     """
-    Sanitize a given name such that it conforms to unix policy.
+    Sanitizes the given name such that it conforms to unix policy.
 
     Args:
         name: the name to sanitize.
@@ -226,7 +226,7 @@ def get_problem_root(problem_name, absolute=False):
 
 def get_problem(problem_path):
     """
-    Retrieve a problem spec from a given problem directory.
+    Returns a problem spec from a given problem directory.
 
     Args:
         problem_path: path to the root of the problem directory.
@@ -271,7 +271,7 @@ def get_bundle_root(bundle_name, absolute=False):
 
 def get_bundle(bundle_path):
     """
-    Retrieve a bundle spec from a given bundle directory.
+    Returns a bundle spec from a given bundle directory.
 
     Args:
         bundle_path: path to the root of the bundle directory.
@@ -296,11 +296,14 @@ def get_bundle(bundle_path):
 
 def verify_config(config_object):
     """
-    Verifies the given configuration dict against the config_schema and the port_range_schema
-    Raise FatalException if failed.
+    Verifies the given configuration dict against the config_schema and the
+    port_range_schema.
 
     Args:
         config_object: The configuration options in a dict
+
+    Raises:
+         FatalException: if failed.
     """
 
     try:
@@ -319,7 +322,7 @@ def verify_config(config_object):
                 "Error validating port range in config file at '%s'!", path)
             logger.critical(e)
             raise FatalException
-        except AssertionError as e:
+        except AssertionError:
             logger.critical("Invalid port range: (%d -> %d)",
                             port_range["start"], port_range["end"])
             raise FatalException
@@ -327,7 +330,7 @@ def verify_config(config_object):
 
 def get_config(path):
     """
-    Retrieve a configuration object from the given path
+    Returns a configuration object from the given path.
 
     Args:
         path: the full path to the json file
@@ -350,7 +353,7 @@ def get_config(path):
 
 def get_hacksports_config():
     """
-    Returns the global configuration options from the file in HACKSPORTS_ROOT
+    Returns the global configuration options from the file in HACKSPORTS_ROOT.
     """
 
     return get_config(join(HACKSPORTS_ROOT, "config.json"))
@@ -358,7 +361,7 @@ def get_hacksports_config():
 
 def write_configuration_file(path, config_dict):
     """
-    Write the options in config_dict to the specified path as JSON
+    Writes the options in config_dict to the specified path as JSON.
 
     Args:
         path: the path of the output JSON file
@@ -375,7 +378,7 @@ def write_configuration_file(path, config_dict):
 
 def write_global_configuration(config_dict):
     """
-    Write the options in config_dict to the global config file
+    Writes the options in config_dict to the global config file.
 
     Args:
         config_dict: the configuration dictionary
@@ -386,10 +389,11 @@ def write_global_configuration(config_dict):
 
 def place_default_config(destination=join(HACKSPORTS_ROOT, "config.json")):
     """
-    Places a default configuration file in the destination
+    Places a default configuration file in the destination.
 
     Args:
-        destination: Where to place the default configuration. Defaults to HACKSPORTS_ROOT/config.json
+        destination: Where to place the default configuration. Defaults to
+            HACKSPORTS_ROOT/config.json
     """
 
     write_configuration_file(destination, default_config)

--- a/picoCTF-shell/shell_manager/util.py
+++ b/picoCTF-shell/shell_manager/util.py
@@ -11,7 +11,8 @@ from os import chmod, listdir, sep, unlink
 from os.path import isdir, isfile, join
 from shutil import copy2, copytree
 
-from voluptuous import All, Length, MultipleInvalid, Range, Required, Schema, ALLOW_EXTRA
+from voluptuous import (All, ALLOW_EXTRA, Length, MultipleInvalid, Range,
+                        Required, Schema)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
* Changes the `isort` [multi-line-output](https://github.com/timothycrosley/isort#multi-line-output-modes) style to *Grid* to match the formatting style of `yapf`.
* Sorts all shell-manager package imports according to `isort`.
* Removes unused imports.
* Fixes some `flake8` style issues, e.g. line too long, unused Exception variables and wrong indentation.
* Fixes some docstrings, e.g. typos, wrong indentation and changes some "imperative" docstrings to "descriptive" (according to [Google Python Style Guide](http://google.github.io/styleguide/pyguide.html))