### PR TITLE
Initial CI config to run flake8 and isort

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,5 @@ matrix:
   include:
     - python: 3.7
       env: TOXENV=flake8
+  allow_failures:
+    - env: TOXENV=flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ sudo: false
 
 language: python
 cache: pip
+
+# turn off notifications
+notifications:
+  email: false
+
+
 before_script:
   - pip install tox
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+os: linux
+dist: xenial
+sudo: false
+
+language: python
+cache: pip
+before_script:
+  - pip install tox
+
+# test script
+script:  tox
+
+matrix:
+  include:
+    - python: 3.7
+      env: TOXENV=flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,23 @@
+[tox]
+# don't perform package operation and install it to virtual env
+skipsdist=True
+envlist = flake8
+
+
+[testenv:flake8]
+description = run flake8 with isort to check code and docstring style
+basepython = python3
+skip_install = true
+deps =
+    flake8
+    flake8-isort
+commands =
+    flake8 picoCTF-web/ picoCTF-shell
+
+
+# Flake8 Configuration
+[flake8]
+exclude =
+    __pycache__,
+    picoCTF-web/test/*,
+    picoCTF-shell/tests/*,


### PR DESCRIPTION
Adds an initial Travis-CI configuration (`.travis.yml`) which calls `tox` to run `flake8` and `flake8-isort`. `flake8` checks *picoCTF-web* and *picoCTF-shell* but excludes the *test* folders. The `flake8-isort` plugin invokes `isort` and will use `.isort.cfg`.

The Python version that is used for the `flake8` code analysis is 3.7.

Related issue #276 