### PR TITLE
Fix port range schema in shell-manager util module

### DIFF
--- a/picoCTF-shell/shell_manager/util.py
+++ b/picoCTF-shell/shell_manager/util.py
@@ -121,9 +121,9 @@ config_schema = Schema(
 
 port_range_schema = Schema({
     Required("start"):
-    All(int, Range(min=0, max=66635)),
+    All(int, Range(min=0, max=65535)),
     Required("end"):
-    All(int, Range(min=0, max=66635))
+    All(int, Range(min=0, max=65535))
 })
 
 


### PR DESCRIPTION
The voluptuous "port_range_schema" in shell_manager.util allowed ports
up to 66635. But a port ranges from 0 to 65535.