### PR TITLE
Add darglint and bandit linter to CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,8 @@ matrix:
   include:
     - python: 3.7
       env: TOXENV=flake8
+    - python: 3.7
+      env: TOXENV=bandit
   allow_failures:
     - env: TOXENV=flake8
+    - env: TOXENV=bandit

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 # don't perform package operation and install it to virtual env
 skipsdist=True
-envlist = flake8
+envlist = flake8, bandit
 
 
 [testenv:flake8]
@@ -11,8 +11,19 @@ skip_install = true
 deps =
     flake8
     flake8-isort
+    darglint
 commands =
-    flake8 picoCTF-web/ picoCTF-shell
+    flake8 picoCTF-web/ picoCTF-shell/
+
+
+[testenv:bandit]
+description = run bandit security linter for picoCTF with {basepython}
+basepython = python3
+skip_install = true
+deps =
+    bandit
+commands =
+    bandit --recursive picoCTF-shell/ picoCTF-web/ --exclude picoCTF-shell/tests/,picoCTF-web/test/
 
 
 # Flake8 Configuration


### PR DESCRIPTION
Adds [darglint](https://pypi.org/project/darglint/) checks to the flake8 CI job, to check that docstrings matches Google style guide. It integrates to flake8, you only have to install the package and you get the additional checks directly in flake8. To run flake8 locally, you only have to install `tox` and run:
```
tox -e flake8
```
Tox will create a virtual environment and install all dependencies for you.

Adds also the [bandit](https://pypi.org/project/bandit/) security linter as another CI job. At the moment, the default configuration is used, but we should use a custom config, later. The job is currently allowed to fail. To run bandit locally, you only have to install `tox` and run:
```
tox -e bandit
```

Related issue #276  