### PR TITLE
Pin the Ansible version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.vagrant
 /terraform.tfstate*
 /dist
+site.retry

--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Defaults for the common role. These are the lowest priority variables
 # and can easily be overridden in group_vars, host_vars, or command line.
-
+ansible_python_interpreter: /usr/bin/python3
 private_repo: False
 
 # Method for synchronizing the picoCTF source to the remote machine

--- a/vagrant/provision_scripts/install_ansible.sh
+++ b/vagrant/provision_scripts/install_ansible.sh
@@ -1,13 +1,10 @@
 #!/bin/bash
 
-# Minimal script to install ansible via apt as described:
-# https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#latest-releases-via-apt-ubuntu
+# Installs Ansible via pip so that we can pin a specific version
 
 # This will get the base boxes to a place where we can use the Vagrant Ansible Local
 # Provisioner: https://www.vagrantup.com/docs/provisioning/ansible_local.html
 
-# Do not pin ansible version, get latest from PyPy
-
-sudo apt-add-repository ppa:ansible/ansible
 sudo apt-get update
-sudo apt-get install -y software-properties-common ansible
+sudo apt-get install -y python3-pip
+sudo pip3 install ansible~=2.7.0


### PR DESCRIPTION
Resolves breaking issue with recently released Ansible 2.8:
```
TASK [pico-web : Synchronize picoCTF-web to a directory on host] ***************
fatal: [dev_web]: FAILED! => {"changed": false, "cmd": "sshpass -d6 /usr/bin/rsync --delay-updates -F --compress --delete-after --archive '--out-format=<<CHANGED>>%i %n%L' /picoCTF/picoCTF-web/ /picoCTF-web-build", "msg": "[Errno 32] Broken pipe", "rc": 32}`
```