### PR TITLE
[Bugfix] Run pinned Ansible with Python 2.7

### DIFF
--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Defaults for the common role. These are the lowest priority variables
 # and can easily be overridden in group_vars, host_vars, or command line.
-ansible_python_interpreter: /usr/bin/python3
+ansible_python_interpreter: /usr/bin/python
 private_repo: False
 
 # Method for synchronizing the picoCTF source to the remote machine

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -22,7 +22,7 @@
 # be loaded in directly via filesystem sync without being cloned from a
 # specific source and branch
 - include: clone_repo.yml
-  when: "'git' in sync_mode"			# coule be git or git_private
+  when: "'git' in sync_mode" # coule be git or git_private
   tags:
     - network
 

--- a/vagrant/provision_scripts/install_ansible.sh
+++ b/vagrant/provision_scripts/install_ansible.sh
@@ -6,5 +6,5 @@
 # Provisioner: https://www.vagrantup.com/docs/provisioning/ansible_local.html
 
 sudo apt-get update
-sudo apt-get install -y python3-pip
-sudo pip3 install ansible~=2.7.0
+sudo apt-get install -y python-pip
+sudo pip install ansible~=2.7.0


### PR DESCRIPTION
Previously, the version of Ansible pulled from their PPA ran using Python 2.
When switching Ansible to a pinned PyPI version in #300, I also switched Ansible to run using Python 3.

This silently broke authentication between the shell server and wetty.js, so this reverts Ansible to run using Python 2 while still pinning its version to 2.7.