### PR TITLE
[Bugfix] v1 minigame submission endpoint

### DIFF
--- a/picoCTF-web/api/apps/v1/minigames.py
+++ b/picoCTF-web/api/apps/v1/minigames.py
@@ -40,7 +40,7 @@ class MinigameSubmissionResponse(Resource):
             raise PicoException('Minigame not found', 404)
 
         hashstring = req['minigame_id'] + curr_user['username'] + \
-            minigame_config.get('secret')
+            settings['minigame']['secret']
 
         if hashlib.md5(hashstring.encode('utf-8')).hexdigest() != \
                 req['verification_key']:


### PR DESCRIPTION
Fixes a bug where the minigame secret could not be found and requests would fail as 500s.