### PR TITLE
Add student batch registration

### DIFF
--- a/picoCTF-web/api/apps/v1/groups.py
+++ b/picoCTF-web/api/apps/v1/groups.py
@@ -343,6 +343,9 @@ class BatchRegistrationResponse(Resource):
             age = fields.Str(
                 data_key='Age', required=True,
                 validate=validate.OneOf(choices=['13-17', '18+']))
+            gender = fields.Str(
+                data_key="Gender", required=False
+            )
             country = fields.Str(
                 data_key='Country/Region of Residence', required=True,
                 validate=validate_country_code)

--- a/picoCTF-web/api/apps/v1/groups.py
+++ b/picoCTF-web/api/apps/v1/groups.py
@@ -311,7 +311,7 @@ class BatchRegistrationResponse(Resource):
             n = int(s)
             if not (1 <= n <= 12):
                 raise ValidationError(
-                    f'Current Year must be between 1 and 12 (provided {s})')
+                    f'Grade must be between 1 and 12 (provided {s})')
 
         def validate_country_code(s):
             if len(s) != 2:
@@ -337,7 +337,7 @@ class BatchRegistrationResponse(Resource):
                 return in_data
 
             current_year = fields.Str(
-                data_key='Current Year (1-12)',
+                data_key='Grade',
                 required=True,
                 validate=validate_current_year)
             age = fields.Str(

--- a/picoCTF-web/api/apps/v1/groups.py
+++ b/picoCTF-web/api/apps/v1/groups.py
@@ -1,12 +1,16 @@
 """Group manangement."""
+import csv
+
 from flask import jsonify
 from flask_restplus import Namespace, Resource
+from marshmallow import (fields, pre_load, RAISE, Schema, validate,
+                         validates_schema, ValidationError, post_load)
 
 import api
 from api import check_csrf, PicoException, require_login, require_teacher
 
-from .schemas import (group_invite_req, group_patch_req, group_remove_team_req,
-                      group_req)
+from .schemas import (batch_registration_req, group_invite_req, group_patch_req,
+                      group_remove_team_req, group_req)
 
 ns = Namespace('groups', description='Group management')
 
@@ -271,3 +275,112 @@ class InviteResponse(Resource):
         return jsonify({
             'success': True
             })
+
+
+@ns.route('/<string:group_id>/batch_registration')
+class BatchRegistrationResponse(Resource):
+    """
+    Register multiple student accounts and assign them to this group.
+
+    Demographics for the registered accounts are provided via CSV upload.
+    """
+
+    @require_teacher
+    @ns.response(200, 'Success')
+    @ns.response(401, 'Not logged in')
+    @ns.response(403, 'Permission denied')
+    @ns.response(404, 'Group not found')
+    @ns.expect(batch_registration_req)
+    def post(self, group_id):
+        """Automatically registers several student accounts based on a CSV."""
+        # Load in student demographics from CSV
+        req = batch_registration_req.parse_args(strict=True)
+        students = []
+        csv_reader = csv.DictReader(
+            req['csv'].read().decode('utf-8').split('\n'))
+        try:
+            for row in csv_reader:
+                students.append(row)
+        except csv.Error as e:
+            raise PicoException(
+                f"Error reading CSV at line {csv_reader.line_num}: {e}",
+                status_code=400)
+
+        # Validate demographics
+        def validate_current_year(s):
+            n = int(s)
+            if not (1 <= n <= 12):
+                raise ValidationError(
+                    f'Current Year must be between 1 and 12 (provided {s})')
+
+        def validate_country_code(s):
+            if len(s) != 2:
+                raise ValidationError(
+                    f'Must be 2-character country code, e.g. "US" \
+                        (provided {s})')
+
+        class BatchRegistrationUserSchema(Schema):
+            # Convert empty strings to Nones when doing validation,
+            # but back before storing in database.
+            @pre_load
+            def empty_to_none(self, in_data):
+                for k, v in in_data.items():
+                    if v == "":
+                        in_data[k] = None
+                return in_data
+
+            @post_load
+            def none_to_empty(self, in_data):
+                for k, v in in_data.items():
+                    if v is None:
+                        in_data[k] = ''
+                return in_data
+
+            current_year = fields.Str(
+                data_key='Current Year (1-12)',
+                required=True,
+                validate=validate_current_year)
+            age = fields.Str(
+                data_key='Age', required=True,
+                validate=validate.OneOf(choices=['13-17', '18+']))
+            country = fields.Str(
+                data_key='Country/Region of Residence', required=True,
+                validate=validate_country_code)
+            email = fields.Email(data_key='Email', required=True)
+            postal_code = fields.Str(
+                data_key='School ZIP/Postal Code', required=True)
+            school_country = fields.Str(
+                data_key='School Country', required=True,
+                validate=validate_country_code
+            )
+            parent_email = fields.Email(
+                data_key='Parent Email (if under 18)', required=True,
+                allow_none=True
+            )
+            @validates_schema
+            def validate_parent_email(self, data):
+                if (data['age'] == '13-17' and
+                        data['parent_email'] is None):
+                    raise ValidationError(
+                        'Parent email must be specified for students under 18')
+        try:
+            students = BatchRegistrationUserSchema().load(
+                students, many=True, unknown=RAISE)
+        except ValidationError as err:
+            raise PicoException(err.messages, status_code=400)
+
+        # Batch-register accounts
+        curr_teacher = api.user.get_user()
+        created_accounts = api.group.batch_register(
+            students, curr_teacher, group_id)
+
+        if len(created_accounts) != len(students):
+            raise PicoException(
+                "An error occurred while adding student accounts. " +
+                f"The first {len(created_accounts)} were created. " +
+                "Please contact an administrator."
+            )
+        return jsonify({
+            'success': True,
+            'accounts': created_accounts
+        })

--- a/picoCTF-web/api/apps/v1/schemas.py
+++ b/picoCTF-web/api/apps/v1/schemas.py
@@ -1,5 +1,6 @@
 """Validation schemas for API requests."""
-from flask_restplus import reqparse, inputs
+import werkzeug.datastructures
+from flask_restplus import inputs, reqparse
 
 
 def object_type(value):
@@ -510,4 +511,12 @@ minigame_submission_req.add_argument(
 minigame_submission_req.add_argument(
     'verification_key', required=True, type=str, location='json',
     help='Verification key for the minigame'
+)
+
+# Batch registration schema
+batch_registration_req = reqparse.RequestParser()
+batch_registration_req.add_argument(
+    'csv', type=werkzeug.datastructures.FileStorage,
+    location='files', required=True,
+    help="Modified copy of the provided batch import CSV"
 )

--- a/picoCTF-web/api/apps/v1/users.py
+++ b/picoCTF-web/api/apps/v1/users.py
@@ -49,6 +49,12 @@ class UserList(Resource):
                 "Must provide a valid parent email address under the key " +
                 "'demo.parentemail'.", status_code=400
             )
+        accepted_genders = ['man', 'woman', 'transgenderman',
+                            'transgenderwoman', 'gfnc']
+        if ('gender' in req['demo'] and
+                req['demo']['gender'] not in accepted_genders):
+            raise PicoException(
+               f"'demo.gender' must be one of: {str(accepted_genders)}", 400)
         if not all([
                 c in string.digits + string.ascii_lowercase for
                 c in req['username'].lower()]):

--- a/picoCTF-web/api/group.py
+++ b/picoCTF-web/api/group.py
@@ -239,7 +239,7 @@ def batch_register(students, teacher, gid):
             # Create a registration token to bypass verification & reCAPTCHA
             rid = api.token.set_token({
                 'gid': gid,
-                'email': student['email'],
+                'email': teacher['email'],
                 'teacher': False
             }, 'registration_token')
             uid = api.user.add_user({
@@ -247,19 +247,20 @@ def batch_register(students, teacher, gid):
                 'password': password,
                 'firstname': '',
                 'lastname': '',
-                'email': student['email'],
-                'country': student['country'],
+                'email': teacher['email'],
+                'country': teacher['country'],
                 'affiliation': api.group.get_group(gid=gid)['name'],
                 'usertype': 'student',
                 'demo': {
                     'age': student['age'],
                     'gender': student['gender'],
                     'grade': student['current_year'],
-                    'parentemail': student['parent_email'],
-                    'residencecountry': student['country'],
-                    'schoolcountry': student['school_country'],
-                    'url': '',
-                    'zipcode': student['postal_code']
+                    'parentemail': teacher['email'],
+                    'residencecountry': teacher['country'],
+                    'schoolcountry': teacher.get('demo', {})
+                                            .get('schoolcountry', ''),
+                    'url': teacher.get('demo', {}).get('url', ''),
+                    'zipcode': teacher.get('demo', {}).get('zipcode', '')
                 },
                 'gid': gid,
                 'rid': rid

--- a/picoCTF-web/api/group.py
+++ b/picoCTF-web/api/group.py
@@ -253,6 +253,7 @@ def batch_register(students, teacher, gid):
                 'usertype': 'student',
                 'demo': {
                     'age': student['age'],
+                    'gender': student['gender'],
                     'grade': student['current_year'],
                     'parentemail': student['parent_email'],
                     'residencecountry': student['country'],

--- a/picoCTF-web/setup.py
+++ b/picoCTF-web/setup.py
@@ -78,7 +78,7 @@ setup(
         'flask-restplus==0.12.1',
         'gunicorn==19.9.0',
         # 'line_profiler==2.1.2',
-        'marshmallow',
+        'marshmallow==3.0.0rc5',
         'py==1.5.3',
         'pymongo==3.7.0',
         'spur==0.3.20',

--- a/picoCTF-web/setup.py
+++ b/picoCTF-web/setup.py
@@ -78,6 +78,7 @@ setup(
         'flask-restplus==0.12.1',
         'gunicorn==19.9.0',
         # 'line_profiler==2.1.2',
+        'marshmallow',
         'py==1.5.3',
         'pymongo==3.7.0',
         'spur==0.3.20',

--- a/picoCTF-web/web/coffee/classroom-management.coffee
+++ b/picoCTF-web/web/coffee/classroom-management.coffee
@@ -144,6 +144,11 @@ BatchRegistrationPanel = React.createClass
       @props.refresh()
     ).bind this
     .error ((jqXHR) ->
+      # If the error is a string
+      if typeof(jqXHR.responseJSON.message) is 'string'
+        apiNotify {"status": 0, "message": jqXHR.responseJSON.message}
+        return
+      # Otherwise, the error is an object of validation errors
       errors = jqXHR.responseJSON.message
       response_html = '<div class="panel panel-danger batch-registration-response"><div class="panel-heading"><h4>Errors found in CSV.</h4>' +
                       '<p>Please resolve the issues below and resubmit:</p>'
@@ -152,9 +157,9 @@ BatchRegistrationPanel = React.createClass
         for field, err_messages of row
           for err_message in err_messages
             if field == '_schema'
-              response_html += '<li>' + err_message + '</li>'
+              response_html += '<li>' + _.escape(err_message) + '</li>'
             else
-              response_html += '<li>' + field + ': ' + err_message + '</li>'
+              response_html += '<li>' + _.escape(field) + ': ' + _.escape(err_message) + '</li>'
         response_html += '</ul>'
       $('.batch-registration-response').remove()
       $('#batch-registration-panel').append(response_html)

--- a/picoCTF-web/web/coffee/classroom-management.coffee
+++ b/picoCTF-web/web/coffee/classroom-management.coffee
@@ -167,15 +167,23 @@ BatchRegistrationPanel = React.createClass
 
   render: ->
     <Panel id="batch-registration-panel">
-      <Col xs={6}>
-        <Button href="/files/picoctf_batch_import.csv">Download Template</Button>
-      </Col>
-      <Col xs={6}>
-        <form>
-          <Input type='file' label='Upload CSV' accept='.csv' ref='fileUpload'/>
-          <Input type='submit' onClick={@handleFileUpload}/>
-        </form>
-      </Col>
+      <Row>
+        <Col xs={12}>
+          <p>{"Batch-register students into this classroom by uploading a CSV of student demographic information. Usernames and passwords will be automatically generated."}</p>
+          <p>{"Please note that your account's email address will be associated with any student accounts created via batch registration."}</p>
+        </Col>
+      </Row>
+      <Row>
+        <Col xs={6}>
+          <Button href="/files/picoctf_batch_import.csv">Download Template</Button>
+        </Col>
+        <Col xs={6}>
+          <form>
+            <Input type='file' label='Upload CSV' accept='.csv' ref='fileUpload'/>
+            <Input type='submit' onClick={@handleFileUpload}/>
+          </form>
+        </Col>
+      </Row>
     </Panel>
 
 MemberManagement = React.createClass

--- a/picoCTF-web/web/coffee/classroom-management.coffee
+++ b/picoCTF-web/web/coffee/classroom-management.coffee
@@ -112,6 +112,67 @@ MemberInvitePanel = React.createClass
       </form>
     </Panel>
 
+BatchRegistrationPanel = React.createClass
+  mixins: [React.addons.LinkedStateMixin]
+
+  propTypes:
+    gid: React.PropTypes.string.isRequired
+
+  handleFileUpload: (e) ->
+    e.preventDefault()
+    formData = new FormData();
+    formData.append('csv', this.refs.fileUpload.getInputDOMNode().files[0]);
+    params = {
+      method: "POST"
+      url: "/api/v1/groups/" + @props.gid + "/batch_registration"
+      data: formData
+      cache: false
+      contentType: false
+      processData: false
+    }
+    $.ajax params
+    .success ((data) ->
+      response_html = '<div class="panel panel-success batch-registration-response"><div class="panel-heading"><h4>Accounts successfully created!</h4>' +
+                      '<p>Usernames and passwords are displayed below in the order of the input CSV.</p>' +
+                      '<p>Please copy these passwords, as they will only be displayed once.</p>' +
+                      '<table class="table">'
+      for i in [0...data.accounts.length]
+        response_html += '<tr><td>' + data.accounts[i].username + '</td><td>' + data.accounts[i].password + '</td></tr>'
+      response_html += '</table></div></div>'
+      $('.batch-registration-response').remove()
+      $('#batch-registration-panel').append(response_html)
+      @props.refresh()
+    ).bind this
+    .error ((jqXHR) ->
+      errors = jqXHR.responseJSON.message
+      response_html = '<div class="panel panel-danger batch-registration-response"><div class="panel-heading"><h4>Errors found in CSV.</h4>' +
+                      '<p>Please resolve the issues below and resubmit:</p>'
+      for row_num, row of errors
+        response_html += '<p><strong>Row ' + (parseInt(row_num) + 1) + ':</strong></p><ul>'
+        for field, err_messages of row
+          for err_message in err_messages
+            if field == '_schema'
+              response_html += '<li>' + err_message + '</li>'
+            else
+              response_html += '<li>' + field + ': ' + err_message + '</li>'
+        response_html += '</ul>'
+      $('.batch-registration-response').remove()
+      $('#batch-registration-panel').append(response_html)
+    ).bind this
+
+  render: ->
+    <Panel id="batch-registration-panel">
+      <Col xs={6}>
+        <Button href="/files/picoctf_batch_import.csv">Download Template</Button>
+      </Col>
+      <Col xs={6}>
+        <form>
+          <Input type='file' label='Upload CSV' accept='.csv' ref='fileUpload'/>
+          <Input type='submit' onClick={@handleFileUpload}/>
+        </form>
+      </Col>
+    </Panel>
+
 MemberManagement = React.createClass
   render: ->
     allMembers = update @props.teacherInformation, {$push: @props.memberInformation}
@@ -126,6 +187,8 @@ MemberManagement = React.createClass
     <Panel>
       <h4>User Management</h4>
       <MemberInvitePanel gid={@props.gid} refresh={@props.refresh}/>
+      <h4>Batch Registration</h4>
+      <BatchRegistrationPanel gid={@props.gid} refresh={@props.refresh}/>
       {memberInformation}
     </Panel>
 

--- a/picoCTF-web/web/coffee/classroom-management.coffee
+++ b/picoCTF-web/web/coffee/classroom-management.coffee
@@ -134,7 +134,7 @@ BatchRegistrationPanel = React.createClass
     .success ((data) ->
       response_html = '<div class="panel panel-success batch-registration-response"><div class="panel-heading"><h4>Accounts successfully created!</h4>' +
                       '<p>Usernames and passwords are displayed below in the order of the input CSV.</p>' +
-                      '<p>Please copy these passwords, as they will only be displayed once.</p>' +
+                      '<p>Please copy these credentials, as they will only be displayed once.</p>' +
                       '<table class="table">'
       for i in [0...data.accounts.length]
         response_html += '<tr><td>' + data.accounts[i].username + '</td><td>' + data.accounts[i].password + '</td></tr>'

--- a/picoCTF-web/web/coffee/front-page.coffee
+++ b/picoCTF-web/web/coffee/front-page.coffee
@@ -401,7 +401,7 @@ LoginForm = React.createClass
             </Col>
           </Row>
           <Row className={showOrHide('class', 'gender')}>
-            <Col md={if @props.gender.value == "other" then 6 else 12}>
+            <Col md={12}>
               <Input type="select" id="gender" name="gender" defaultValue="" label="Which gender identity do you most identify with?" valueLink={@props.gender}>
                   <option value="">-Select-</option>
                   <option value="woman">Woman</option>
@@ -409,12 +409,7 @@ LoginForm = React.createClass
                   <option value="transgenderwoman">Transgender Woman</option>
                   <option value="transgenderman">Transgender Man</option>
                   <option value="gfnc">Gender Fluid/Non-Conforming</option>
-                  <option value="other">I prefer: (fill in)</option>
               </Input>
-            </Col>
-            <Col md={6} className={if @props.gender.value == "other" then "show" else "hide"}>
-              <br/>
-              <Input type="text" name="genderother" disabled={if @props.gender.value == "other" then false else true} id="genderother" valueLink={@props.genderother} label="Gender preference" placeholder=""/>
             </Col>
           </Row>
           <Row>
@@ -585,10 +580,6 @@ AuthPanel = React.createClass
     form.usertype = @state.usertype
     form.demo = {}
 
-    if @state.demo_gender == "other"
-      @state.demo_gender = @state.demo_genderother
-      delete @state.demo_genderother
-
     for k,v of @state
       if k.substr(0,5) == "demo_"
         form.demo[k.substr(5)] = v
@@ -694,7 +685,6 @@ AuthPanel = React.createClass
     grade: @linkState "demo_grade"
     referrer: @linkState "demo_referrer"
     gender: @linkState "demo_gender"
-    genderother: @linkState "demo_genderother"
     teacher_middleschool: @linkState "demo_teacher_middleschool"
     teacher_highschool: @linkState "demo_teacher_highscool"
     teacher_afterschoolclub: @linkState "demo_teacher_afterschool"

--- a/picoCTF-web/web/files/picoctf_batch_import.csv
+++ b/picoCTF-web/web/files/picoctf_batch_import.csv
@@ -1,3 +1,3 @@
-Grade,Age,Country/Region of Residence,Email,School ZIP/Postal Code,School Country,Parent Email (if under 18)
-8,13-17,US,student@sample.com,15206,US,parent@sample.com
-12,18+,CA,student2@sample.com,M3C 0H9,CA,
+Grade,Age,Gender,Country/Region of Residence,Email,School ZIP/Postal Code,School Country,Parent Email (if under 18)
+8,13-17,man,US,student@sample.com,15206,US,parent@sample.com
+12,18+,woman,CA,student2@sample.com,M3C 0H9,CA,

--- a/picoCTF-web/web/files/picoctf_batch_import.csv
+++ b/picoCTF-web/web/files/picoctf_batch_import.csv
@@ -1,0 +1,3 @@
+Current Year (1-12),Age,Country/Region of Residence,Email,School ZIP/Postal Code,School Country,Parent Email (if under 18)
+8,13-17,US,student@sample.com,15206,US,parent@sample.com
+12,18+,CA,student2@sample.com,M3C 0H9,CA,

--- a/picoCTF-web/web/files/picoctf_batch_import.csv
+++ b/picoCTF-web/web/files/picoctf_batch_import.csv
@@ -1,3 +1,3 @@
-Current Year (1-12),Age,Country/Region of Residence,Email,School ZIP/Postal Code,School Country,Parent Email (if under 18)
+Grade,Age,Country/Region of Residence,Email,School ZIP/Postal Code,School Country,Parent Email (if under 18)
 8,13-17,US,student@sample.com,15206,US,parent@sample.com
 12,18+,CA,student2@sample.com,M3C 0H9,CA,

--- a/picoCTF-web/web/files/picoctf_batch_import.csv
+++ b/picoCTF-web/web/files/picoctf_batch_import.csv
@@ -1,3 +1,3 @@
-Grade,Age,Gender,Country/Region of Residence,Email,School ZIP/Postal Code,School Country,Parent Email (if under 18)
-8,13-17,man,US,student@sample.com,15206,US,parent@sample.com
-12,18+,woman,CA,student2@sample.com,M3C 0H9,CA,
+Grade (1-12),Age (13-17 or 18+),Gender
+8,13-17,man
+12,18+,woman


### PR DESCRIPTION
Adds a module to the classroom management view allowing teachers to batch-register students by uploading a CSV.

Batch-registered accounts:
- Require only Age, Grade, and (optionally) Gender fields to be filled out
  - Email, parent email, country of residence, and school name/country/ZIP code/URL are pulled from the initiating teacher account and group
- Bypass email verification and reCAPTCHA, if enabled
- Have usernames of the form `<teacher_username>.<student_n>`. Since `.` is typically disallowed for usernames, these accounts are guaranteed to be available
- Have automatically generated passwords, which are displayed once at registration time or can otherwise be changed through password reset
- Are automatically added to the classroom from which they were added

The underlying API call is: `POST /api/v1/groups/<gid>/batch_registration`, which accepts a CSV with name `csv` as its only `form-data` parameter.

Closes #221