### PR TITLE
Delete Account and hidepid

### DIFF
--- a/ansible/roles/pico-shell/tasks/main.yml
+++ b/ansible/roles/pico-shell/tasks/main.yml
@@ -27,6 +27,9 @@
     state: started
     enabled: yes
 
+- name: hidepid
+  command: mount -o remount,hidepid=2 /proc
+
 - name: Copy over 99-motd
   copy:
     src: 99-motd

--- a/ansible/roles/pico-shell/tasks/main.yml
+++ b/ansible/roles/pico-shell/tasks/main.yml
@@ -27,8 +27,11 @@
     state: started
     enabled: yes
 
-- name: hidepid
+- name: Hidepid
   command: mount -o remount,hidepid=2 /proc
+
+- name: Hidepid persistence
+  command: echo "proc   /proc   proc  defaults,hidepid=2  0   0"  >> /etc/fstab
 
 - name: Copy over 99-motd
   copy:

--- a/picoCTF-web/api/apps/v1/user.py
+++ b/picoCTF-web/api/apps/v1/user.py
@@ -50,7 +50,7 @@ class LoginResponse(Resource):
     @ns.response(200, 'Sucess')
     @ns.response(400, 'Error parsing request')
     @ns.response(401, 'Incorrect username or password')
-    @ns.response(403, 'Account disabled or not yet verified')
+    @ns.response(403, 'Account deleted or not yet verified')
     @ns.expect(login_req)
     def post(self):
         """Log in."""

--- a/picoCTF-web/api/team.py
+++ b/picoCTF-web/api/team.py
@@ -269,7 +269,7 @@ def get_team_information(tid):
     return team_info
 
 
-def is_eligible(tid):
+def is_eligible(tid, show_disabled=False):
     """
     Return a team's eligibility for the current event.
 

--- a/picoCTF-web/api/team.py
+++ b/picoCTF-web/api/team.py
@@ -269,7 +269,7 @@ def get_team_information(tid):
     return team_info
 
 
-def is_eligible(tid, show_disabled=False):
+def is_eligible(tid):
     """
     Return a team's eligibility for the current event.
 
@@ -278,7 +278,7 @@ def is_eligible(tid, show_disabled=False):
     Returns:
         True or False
     """
-    members = get_team_members(tid)
+    members = get_team_members(tid, show_disabled=False)
     conditions = api.config.get_settings()['eligibility']
     for member in members:
         is_eligible = all(

--- a/picoCTF-web/api/user.py
+++ b/picoCTF-web/api/user.py
@@ -356,10 +356,10 @@ def disable_account(uid):
         "disabled": False
     }, {"$set": {
         "disabled": True,
-        "firstname": "",
-        "lastname": "",
-        "email": "",
-        "country": "",
+        "firstname": "null",
+        "lastname": "null",
+        "email": "null",
+        "country": "null",
         "demo" : "{}"
     }})
 
@@ -441,7 +441,7 @@ def login(username, password):
         raise PicoException('Incorrect username.', 401)
 
     if user['disabled']:
-        raise PicoException('This account has been disabled.', 403)
+        raise PicoException('This account has been deleted.', 403)
 
     if not user['verified']:
         raise PicoException('This account has not been verified yet.', 403)

--- a/picoCTF-web/api/user.py
+++ b/picoCTF-web/api/user.py
@@ -341,6 +341,8 @@ def update_password_request(params, uid=None, check_current=False):
 @log_action
 def disable_account(uid):
     """
+    Note: The original disable account has now been updated to perform delete account instead.
+
     Disables a user account.
 
     Disabled user accounts can't login or consume space on a team.
@@ -351,8 +353,14 @@ def disable_account(uid):
     db = api.db.get_conn()
     db.users.find_one_and_update({
         "uid": uid,
+        "disabled": False
     }, {"$set": {
-        "disabled": True
+        "disabled": True,
+        "firstname": "null",
+        "lastname": "null",
+        "email": "null",
+        "country": "null",
+        "demo" : "{}"
     }})
 
     db.teams.find_one_and_update(

--- a/picoCTF-web/api/user.py
+++ b/picoCTF-web/api/user.py
@@ -356,10 +356,10 @@ def disable_account(uid):
         "disabled": False
     }, {"$set": {
         "disabled": True,
-        "firstname": "null",
-        "lastname": "null",
-        "email": "null",
-        "country": "null",
+        "firstname": "",
+        "lastname": "",
+        "email": "",
+        "country": "",
         "demo" : "{}"
     }})
 

--- a/picoCTF-web/web/account.html
+++ b/picoCTF-web/web/account.html
@@ -43,19 +43,19 @@ startup_functions:
     <div class="col-md-6">
       <div class="panel panel-danger">
         <div class="panel-heading">
-          <h3 class="panel-title">Disable Account</h3>
+          <h3 class="panel-title">Delete Account</h3>
           <em>This is permanent action; you can not undo this.</em>
         </div>
         <div class="panel-body">
           <div class="col-md-10 col-md-offset-1">
             <form role="form" id="disable-account-form">
-              <p>Disabling your account will remove you from the competition. You will not be able to log in once you disable your account. Disabled accounts cannot be re-enabled.</p>
+              <p>Deleting your account will remove you from the competition. You will not be able to log in once you delete your account. Deleted accounts cannot be re-enabled.</p>
               <div class="form-group">
                 <label for="current-password" class="control-label">Current Password</label>
                 <input name="current-password" id="current-password-disable" class="form-control" type="password" placeholder="Current Password">
               </div>
               <div class="form-group">
-                <button id="disable-account-button" class="btn btn-danger" type="submit">Disable Account</button>
+                <button id="disable-account-button" class="btn btn-danger" type="submit">Delete Account</button>
               </div>
             </form>
           </div>

--- a/picoCTF-web/web/coffee/account.coffee
+++ b/picoCTF-web/web/coffee/account.coffee
@@ -27,13 +27,13 @@ resetPassword = (e) ->
 
 disableAccount = (e) ->
   e.preventDefault()
-  confirmDialog "This will disable your account, drop you from your team, and prevent you from playing!", "Disable Account Confirmation", "Disable Account", "Cancel", () ->
+  confirmDialog "This will delete your account, drop you from your team, and prevent you from playing!", "Delete Account Confirmation", "Delete Account", "Cancel", () ->
     data = {
       "password": $("#disable-account-form input[name=current-password]").val()
     }
     apiCall "POST", "/api/v1/user/disable_account", data, 'Authentication', 'DisableAccount'
     .success (data) ->
-      apiNotify {"status": 1, "message": "Your account has been disabled"}, "/"
+      apiNotify {"status": 1, "message": "Your account has been Deleted."}, "/"
     .error (jqXHR) ->
       apiNotify {"status": 0, "message": jqXHR.responseJSON.message}
 

--- a/picoCTF-web/web/coffee/account.coffee
+++ b/picoCTF-web/web/coffee/account.coffee
@@ -33,7 +33,7 @@ disableAccount = (e) ->
     }
     apiCall "POST", "/api/v1/user/disable_account", data, 'Authentication', 'DisableAccount'
     .success (data) ->
-      apiNotify {"status": 1, "message": "Your account has been Deleted."}, "/"
+      apiNotify {"status": 1, "message": "Your account has been deleted."}, "/"
     .error (jqXHR) ->
       apiNotify {"status": 0, "message": jqXHR.responseJSON.message}
 


### PR DESCRIPTION
Disable account was updated to delete account where only the uid, username, password_hash and tid are saved while all other user details are made as null.

Closes #267 