### PR TITLE
Update team eligibility behavior re: disabled accounts

### DIFF
--- a/picoCTF-web/api/apps/v1/user.py
+++ b/picoCTF-web/api/apps/v1/user.py
@@ -142,6 +142,7 @@ class DisableAccountResponse(Resource):
                 req['password'], user['password_hash']):
             raise PicoException('The provided password is not correct.', 422)
         api.user.disable_account(user['uid'])
+        api.user.logout()
         return jsonify({
             'success': True
             })

--- a/picoCTF-web/api/apps/v1/users.py
+++ b/picoCTF-web/api/apps/v1/users.py
@@ -82,3 +82,14 @@ class User(Resource):
         if not res:
             raise PicoException('User not found', status_code=404)
         return res, 200
+
+    @require_admin
+    def delete(self, user_id):
+        """Disable a specific user."""
+        user = api.user.get_user(uid=user_id)
+        if not user:
+            raise PicoException('User not found', status_code=404)
+        api.user.disable_account(user_id)
+        return jsonify({
+            'success': True
+        })

--- a/picoCTF-web/api/team.py
+++ b/picoCTF-web/api/team.py
@@ -282,7 +282,7 @@ def is_eligible(tid):
     Returns:
         True or False
     """
-    members = get_team_members(tid)
+    members = get_team_members(tid, show_disabled=False)
     conditions = api.config.get_settings()['eligibility']
     for member in members:
         is_eligible = all(


### PR DESCRIPTION
Resolves #316 

- Team eligibility is calculated based on non-disabled members only
- To prevent an ineligible member from helping a team and then self-disabling, ineligibility is now "sticky". However, a team formerly known to be eligible is still checked every time
- Added `/teams/<tid>/recalculate_eligibility`, where an admin can force a re-evaluation of a team's eligibility in the case of honest mistakes
- Added `DELETE /user/<uid>`, allowing an admin to directly disable an account. Previously, a user could only self-disable their account with password confirmation using `POST /user/disable_account`
- Teams' countries are recalculated when a member leaves (is disabled). If this causes a formerly 
mixed-country team to become homogenous again, its country will update from `??` to e.g. `CA`.