### PR TITLE
Suppress the Server header in responses

### DIFF
--- a/ansible/roles/pico-shell/tasks/dependencies.yml
+++ b/ansible/roles/pico-shell/tasks/dependencies.yml
@@ -29,6 +29,7 @@
       'libssl-dev',
       'netfilter-persistent',
       'nginx',
+      'nginx-extras',
       'nodejs',
       'php7.2-cli',       # php5 package deprecated
       'php7.2-sqlite3',   # used to serve challenge binaries

--- a/ansible/roles/pico-shell/templates/shell.nginx.j2
+++ b/ansible/roles/pico-shell/templates/shell.nginx.j2
@@ -14,6 +14,8 @@ server {
     listen       80;
     {% endif %}
 
+    more_clear_headers Server;
+
     location /shell {
         proxy_pass http://127.0.0.1:{{ wetty_port }}/shell;
         proxy_set_header Host $host;

--- a/ansible/roles/pico-web/tasks/dependencies.yml
+++ b/ansible/roles/pico-web/tasks/dependencies.yml
@@ -15,6 +15,7 @@
         'libffi-dev',
         'libssl-dev',
         'nginx',
+        'nginx-extras',
         'python-virtualenv',
         'python3-pip',
         'python3.7-dev',

--- a/ansible/roles/pico-web/templates/ctf.nginx.j2
+++ b/ansible/roles/pico-web/templates/ctf.nginx.j2
@@ -26,6 +26,8 @@ server {
         error_page 404  = /404.html;
         error_page 401  = /401.html;
 
+        more_clear_headers Server;
+
         {% if enable_basic_auth -%}
         satisfy any;
 


### PR DESCRIPTION
Prevents `Server: nginx/$VERSION (Ubuntu)` from being returned in HTTP responses, as noted by @archituiet 