### PR TITLE
Sanitize team and classroom names

### DIFF
--- a/picoCTF-web/api/apps/v1/groups.py
+++ b/picoCTF-web/api/apps/v1/groups.py
@@ -51,7 +51,8 @@ class GroupList(Resource):
                 c in string.digits + string.ascii_lowercase + " ()-,#'&"
                 for c in req['name'].lower()]):
             raise PicoException(
-                'Classroom names must be alphanumeric.', status_code=400
+                "Classroom names cannot contain special characters other than"+
+                "()-,#'&", status_code=400
             )
 
         gid = api.group.create_group(curr_tid, req['name'])

--- a/picoCTF-web/api/apps/v1/groups.py
+++ b/picoCTF-web/api/apps/v1/groups.py
@@ -48,8 +48,8 @@ class GroupList(Resource):
             raise PicoException(
                 'You already have a classroom with that name', 409)
         if not all([
-                c in string.digits + string.ascii_lowercase for
-                c in req['name'].lower()]):
+                c in string.digits + string.ascii_lowercase + "\n()-,#'&"
+                for c in req['name'].lower()]):
             raise PicoException(
                 'Classroom names must be alphanumeric.', status_code=400
             )

--- a/picoCTF-web/api/apps/v1/groups.py
+++ b/picoCTF-web/api/apps/v1/groups.py
@@ -48,7 +48,7 @@ class GroupList(Resource):
             raise PicoException(
                 'You already have a classroom with that name', 409)
         if not all([
-                c in string.digits + string.ascii_lowercase + "\n()-,#'&"
+                c in string.digits + string.ascii_lowercase + " ()-,#'&"
                 for c in req['name'].lower()]):
             raise PicoException(
                 'Classroom names must be alphanumeric.', status_code=400

--- a/picoCTF-web/api/apps/v1/groups.py
+++ b/picoCTF-web/api/apps/v1/groups.py
@@ -51,7 +51,7 @@ class GroupList(Resource):
                 c in string.digits + string.ascii_lowercase + " ()-,#'&"
                 for c in req['name'].lower()]):
             raise PicoException(
-                "Classroom names cannot contain special characters other than"+
+                "Classroom names cannot contain special characters other than "+
                 "()-,#'&", status_code=400
             )
 

--- a/picoCTF-web/api/apps/v1/groups.py
+++ b/picoCTF-web/api/apps/v1/groups.py
@@ -1,5 +1,6 @@
 """Group manangement."""
 import csv
+import string
 
 from flask import jsonify
 from flask_restplus import Namespace, Resource
@@ -46,6 +47,12 @@ class GroupList(Resource):
                 name=req['name'], owner_tid=curr_tid) is not None:
             raise PicoException(
                 'You already have a classroom with that name', 409)
+        if not all([
+                c in string.digits + string.ascii_lowercase for
+                c in req['name'].lower()]):
+            raise PicoException(
+                'Classroom names must be alphanumeric.', status_code=400
+            )
 
         gid = api.group.create_group(curr_tid, req['name'])
         res = jsonify({

--- a/picoCTF-web/api/apps/v1/schemas.py
+++ b/picoCTF-web/api/apps/v1/schemas.py
@@ -421,8 +421,8 @@ team_change_req.add_argument(
 # Team request
 team_req = reqparse.RequestParser()
 team_req.add_argument(
-    'team_name', required=True, type=str, location='json',
-    help='Name of the new team'
+    'team_name', required=True, type=length_restricted(3, 100, str),
+    location='json', help='Name of the new team'
 )
 team_req.add_argument(
     'team_password', required=True, type=length_restricted(3, 20, str),

--- a/picoCTF-web/api/apps/v1/schemas.py
+++ b/picoCTF-web/api/apps/v1/schemas.py
@@ -497,7 +497,7 @@ team_change_req.add_argument(
 team_req = reqparse.RequestParser()
 team_req.add_argument(
     'team_name', required=True, type=length_restricted(3, 100, str),
-    location='json', help='Name of the new team'
+    location='json', help='Name of the new team',
     error='A name for the new team is required'
 )
 team_req.add_argument(

--- a/picoCTF-web/api/apps/v1/teams.py
+++ b/picoCTF-web/api/apps/v1/teams.py
@@ -33,7 +33,7 @@ class TeamList(Resource):
                 'Teachers may not create teams', 403
             )
         if not all([
-                c in string.digits + string.ascii_lowercase + "\n()+-,#'*&!?"
+                c in string.digits + string.ascii_lowercase + " ()+-,#'*&!?"
                 for c in req['team_name'].lower()]):
             raise PicoException(
                 'Team names must be alphanumeric.', status_code=400

--- a/picoCTF-web/api/apps/v1/teams.py
+++ b/picoCTF-web/api/apps/v1/teams.py
@@ -33,8 +33,8 @@ class TeamList(Resource):
                 'Teachers may not create teams', 403
             )
         if not all([
-                c in string.digits + string.ascii_lowercase for
-                c in req['team_name'].lower()]):
+                c in string.digits + string.ascii_lowercase + "\n()+-,#'*&!?"
+                for c in req['team_name'].lower()]):
             raise PicoException(
                 'Team names must be alphanumeric.', status_code=400
             )

--- a/picoCTF-web/api/apps/v1/teams.py
+++ b/picoCTF-web/api/apps/v1/teams.py
@@ -36,7 +36,7 @@ class TeamList(Resource):
                 c in string.digits + string.ascii_lowercase + " ()+-,#'*&!?"
                 for c in req['team_name'].lower()]):
             raise PicoException(
-                "Team names cannot contain special characters other than"+
+                "Team names cannot contain special characters other than "+
                 "()+-,#'*&!?", status_code=400
             )
 

--- a/picoCTF-web/api/apps/v1/teams.py
+++ b/picoCTF-web/api/apps/v1/teams.py
@@ -1,4 +1,6 @@
 """Team related endpoints."""
+import string
+
 from flask import jsonify
 from flask_restplus import Namespace, Resource
 
@@ -30,6 +32,13 @@ class TeamList(Resource):
             raise PicoException(
                 'Teachers may not create teams', 403
             )
+        if not all([
+                c in string.digits + string.ascii_lowercase for
+                c in req['team_name'].lower()]):
+            raise PicoException(
+                'Team names must be alphanumeric.', status_code=400
+            )
+
         new_tid = api.team.create_and_join_new_team(
             req['team_name'],
             req['team_password'],

--- a/picoCTF-web/api/apps/v1/teams.py
+++ b/picoCTF-web/api/apps/v1/teams.py
@@ -36,7 +36,8 @@ class TeamList(Resource):
                 c in string.digits + string.ascii_lowercase + " ()+-,#'*&!?"
                 for c in req['team_name'].lower()]):
             raise PicoException(
-                'Team names must be alphanumeric.', status_code=400
+                "Team names cannot contain special characters other than"+
+                "()+-,#'*&!?", status_code=400
             )
 
         new_tid = api.team.create_and_join_new_team(

--- a/picoCTF-web/tests/api/functional/v1/test_teams.py
+++ b/picoCTF-web/tests/api/functional/v1/test_teams.py
@@ -47,10 +47,10 @@ def test_create_team(mongo_proc, client): # noqa (fixture)
     # Add a mock team and attempt to create a team with the same name
     db = get_conn()
     db.teams.insert({
-        'team_name': 'test_teamname'
+        'team_name': 'test teamname'
     })
     res = client.post('/api/v1/teams', json={
-        'team_name': 'test_teamname',
+        'team_name': 'test teamname',
         'team_password': 'newteam'
     })
     assert res.status_code == 409


### PR DESCRIPTION
Limit the acceptable characters when creating teams and classrooms to prevent abuse.

resolves #335 