### PR TITLE
Fix permissions setting of /tmp breaking uwsgi

### DIFF
--- a/ansible/roles/pico-shell/tasks/deploy_problems.yml
+++ b/ansible/roles/pico-shell/tasks/deploy_problems.yml
@@ -48,7 +48,7 @@
   become: true
   file:
     path: /tmp
-    mode: 1773
+    mode: '1773'
 
 - name: Change /etc/xinetd.d permission
   become: true


### PR DESCRIPTION
Newer ansible expects octal or string representations.

Fixes broken launch of web problems and who knows what else

Resolves #341