### PR TITLE
Standardize octal format of ansible perm setting

### DIFF
--- a/ansible/roles/pico-shell/tasks/deploy_problems.yml
+++ b/ansible/roles/pico-shell/tasks/deploy_problems.yml
@@ -48,13 +48,13 @@
   become: true
   file:
     path: /tmp
-    mode: '1773'
+    mode: 01773
 
 - name: Change /etc/xinetd.d permission
   become: true
   file:
     path: /etc/xinetd.d
-    mode: 750
+    mode: 0750
 
 # generally a good idea (on remote, we will find dist.bundle)
 - name: Exclude group and others from ansible_user home directory


### PR DESCRIPTION
Followup, update format in c391fb7 to be consistent

`/etc/xinet.d` was incorrect assigned as well