### PR TITLE
Remove service start delay on web, use vagrant to restart services

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -78,6 +78,9 @@ Vagrant.configure("2") do |config|
       ansible.verbose = ENV['V']
     end
 
+    web.vm.provision "shell", run: "always", inline: "systemctl restart gunicorn.service"
+    web.vm.provision "shell", run: "always", inline: "systemctl restart ctf-daemon.service"
+
     web.vm.provider "virtualbox" do |vb|
       vb.name = "picoCTF-web-dev" + compute_auto_name_suffix()
       # Overridable settings

--- a/ansible/roles/pico-web/templates/ctf-daemon.service.j2
+++ b/ansible/roles/pico-web/templates/ctf-daemon.service.j2
@@ -1,11 +1,10 @@
 [Unit]
 Description= ctf daemon runner
-After=network.target vboxadd-service.service
+After=network.target
 
 [Service]
 Type=simple
 Environment="APP_SETTINGS_FILE={{ web_config_dir }}/deploy_settings.py"
-ExecStartPre=/bin/sleep 15
 ExecStart={{ virtualenv_dir }}/bin/daemon_manager -d {{ daemon_src_dir }} cache_stats share_instances
 RestartSec="5min"
 Restart=always

--- a/ansible/roles/pico-web/templates/gunicorn.service.j2
+++ b/ansible/roles/pico-web/templates/gunicorn.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=gunicorn daemon
 Requires=gunicorn.socket
-After=network.target vboxadd-service.service
+After=network.target
 
 [Service]
 Environment="APP_SETTINGS_FILE={{ web_config_dir }}/deploy_settings.py"
@@ -9,7 +9,6 @@ PIDFile=/run/gunicorn/pid
 User= {{ gunicorn_user }}
 Group= {{ gunicorn_group }}
 WorkingDirectory= {{ gunicorn_working_dir }}
-ExecStartPre=/bin/sleep 15
 ExecStart={{ virtualenv_dir }}/bin/gunicorn --max-requests 2000 --pid /run/gunicorn/pid -b {{ gunicorn_listen_on }} -w {{ num_workers }} 'api:create_app()'
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID


### PR DESCRIPTION
Note: does not appear to be possible to address the vagrant mount order
issue with systemd dependencies, as sync occurs sometime after
systemd units are all loaded.

Resolves #260