### PR TITLE
Trim data from user and team endpoints extraneous to front-end

### DIFF
--- a/picoCTF-web/api/apps/v1/team.py
+++ b/picoCTF-web/api/apps/v1/team.py
@@ -11,6 +11,12 @@ from .schemas import (join_group_req, score_progression_req, team_change_req,
 
 ns = Namespace('team', description="Information about the current user's team")
 
+TEAMDATA_FILTER = ['achievements', 'eligibile', 'max_team_size', 'members',
+                   'progression', 'score', 'size', 'solved_problems',
+                   'team_name', 'tid']
+
+TEAMMEMBER_FILTER = ['affiliation', 'country', 'username', 'usertype']
+
 
 @ns.route('')
 class Team(Resource):
@@ -22,7 +28,13 @@ class Team(Resource):
     def get(self):
         """Get information about the current user's team."""
         current_tid = api.user.get_user()['tid']
-        return jsonify(api.team.get_team_information(current_tid))
+        teamdata = {k: v for k, v in
+                    api.team.get_team_information(current_tid).items() if
+                    k in TEAMDATA_FILTER}
+        members = list(map(lambda member: {k: v for k, v in member.items() if
+                           k in TEAMMEMBER_FILTER}, teamdata['members']))
+        teamdata['members'] = members
+        return jsonify(teamdata)
 
 
 # @TODO doesn't make sense to return score in both /team and /team/score

--- a/picoCTF-web/api/apps/v1/team.py
+++ b/picoCTF-web/api/apps/v1/team.py
@@ -11,9 +11,9 @@ from .schemas import (join_group_req, score_progression_req, team_change_req,
 
 ns = Namespace('team', description="Information about the current user's team")
 
-TEAMDATA_FILTER = ['achievements', 'eligibile', 'max_team_size', 'members',
-                   'progression', 'score', 'size', 'solved_problems',
-                   'team_name', 'tid']
+TEAMDATA_FILTER = ['achievements', 'affiliation', 'eligible', 'max_team_size',
+                   'members', 'progression', 'score', 'size',
+                   'solved_problems', 'team_name', 'tid']
 
 TEAMMEMBER_FILTER = ['affiliation', 'country', 'username', 'usertype']
 

--- a/picoCTF-web/api/apps/v1/user.py
+++ b/picoCTF-web/api/apps/v1/user.py
@@ -12,6 +12,9 @@ from .schemas import (disable_account_req, email_verification_req, login_req,
 ns = Namespace('user', description='Authentication and information about ' +
                                    'current user')
 
+USERDATA_FILTER = ['admin', 'extdata', 'completed_minigames', 'logged_in',
+                    'teacher', 'tokens', 'unlocked_walkthroughs', 'username',
+                    'verified']
 
 @ns.route('')
 class User(Resource):
@@ -25,7 +28,9 @@ class User(Resource):
         }
         if api.user.is_logged_in():
             res['logged_in'] = True
-            res.update(api.user.get_user())
+            userdata = {k: v for k, v in api.user.get_user().items() if
+                        k in USERDATA_FILTER}
+            res.update(userdata)
         return jsonify(res)
 
     @check_csrf

--- a/picoCTF-web/api/team.py
+++ b/picoCTF-web/api/team.py
@@ -6,6 +6,8 @@ import api
 from api import cache, check, log_action, PicoException
 from api.cache import memoize
 
+PROBLEMSOLVED_FILTER = ['category', 'name', 'score', 'solve_time']
+
 new_team_schema = Schema({
     Required("team_name"):
     check(
@@ -245,7 +247,6 @@ def get_team_information(tid):
         "country": member["country"],
         "usertype": member["usertype"],
     } for member in get_team_members(tid=tid, show_disabled=False)]
-    team_info["competition_active"] = api.config.check_competition_active()
     team_info["progression"] = api.stats.get_score_progression(tid=tid)
     team_info["flagged_submissions"] = [
         sub for sub in api.stats.check_invalid_instance_submissions()
@@ -259,12 +260,9 @@ def get_team_information(tid):
 
     team_info["solved_problems"] = []
     for solved_problem in api.problem.get_solved_problems(tid=tid):
-        solved_problem.pop("instances", None)
-        solved_problem.pop("pkg_dependencies", None)
-        solved_problem.pop("hints", None)
-        solved_problem.pop("author", None)
-        solved_problem.pop("organization", None)
-        team_info["solved_problems"].append(solved_problem)
+        filtered_problem = {k: v for k, v in solved_problem.items() if
+                            k in PROBLEMSOLVED_FILTER}
+        team_info["solved_problems"].append(filtered_problem)
 
     # Teams flagged as ineligible once will not recalculate their eligibility
     if team_info.get("eligible", True):

--- a/picoCTF-web/tests/api/functional/v1/test_team.py
+++ b/picoCTF-web/tests/api/functional/v1/test_team.py
@@ -30,10 +30,7 @@ def test_get_my_team(mongo_proc, redis_proc, client): # noqa (fixture)
     expected_fields = {
         'achievements': [],
         'affiliation': STUDENT_DEMOGRAPHICS['affiliation'],
-        'competition_active': False,
-        'country': 'US',
         'eligible': True,
-        'flagged_submissions': [],
         'max_team_size': 1,
         'progression': [],
         'score': 0,
@@ -43,9 +40,6 @@ def test_get_my_team(mongo_proc, redis_proc, client): # noqa (fixture)
         }
     expected_member_fields = {
         'country': STUDENT_DEMOGRAPHICS['country'],
-        'email': STUDENT_DEMOGRAPHICS['email'],
-        'firstname': STUDENT_DEMOGRAPHICS['firstname'],
-        'lastname': STUDENT_DEMOGRAPHICS['lastname'],
         'username': STUDENT_DEMOGRAPHICS['username'],
         'usertype': 'student'
     }
@@ -57,10 +51,6 @@ def test_get_my_team(mongo_proc, redis_proc, client): # noqa (fixture)
     assert len(res.json['members']) == 1
     for k, v in expected_member_fields.items():
         assert res.json['members'][0][k] == v
-
-    db = get_conn()
-    uid = db.users.find_one({'username': STUDENT_DEMOGRAPHICS['username']})['uid']
-    assert res.json['members'][0]['uid'] == uid
 
 
 def test_get_my_team_score(mongo_proc, redis_proc, client): # noqa (fixture)

--- a/picoCTF-web/tests/api/functional/v1/test_user.py
+++ b/picoCTF-web/tests/api/functional/v1/test_user.py
@@ -349,23 +349,12 @@ def test_get_user(mongo_proc, redis_proc, client): # noqa (fixture)
     expected_body = {
         'admin': False,
         'completed_minigames': [],
-        'country': STUDENT_DEMOGRAPHICS['country'],
-        'demo': {
-            'age': STUDENT_DEMOGRAPHICS['demo']['age'],
-            'parentemail': STUDENT_DEMOGRAPHICS['demo']['parentemail']},
-        'disabled': False,
-        'email': STUDENT_DEMOGRAPHICS['email'],
         'extdata': {},
-        'firstname': STUDENT_DEMOGRAPHICS['firstname'],
-        'lastname': STUDENT_DEMOGRAPHICS['lastname'],
         'logged_in': True,
         'teacher': False,
-        'tid': '8b19b0478dcc43e7a448a4e500584c10',
         'tokens': 0,
-        'uid': 'dc7089e279d24b70b989cd53665eb49c',
         'unlocked_walkthroughs': [],
         'username': STUDENT_DEMOGRAPHICS['username'],
-        'usertype': 'student',
         'verified': True
         }
     res = client.get('/api/v1/user')


### PR DESCRIPTION
Leaves some extra team data internally for group-related calls.

Removes most of problem data even for admins, as that is otherwise available from
problem routes.