### PR TITLE
Making GET and PATCH /v1/settings use the same time format

### DIFF
--- a/picoCTF-web/api/apps/v1/schemas.py
+++ b/picoCTF-web/api/apps/v1/schemas.py
@@ -165,14 +165,14 @@ settings_patch_req.add_argument(
     error='enable_feedback must be a boolean'
 )
 settings_patch_req.add_argument(
-    'start_time', required=False, type=inputs.datetime_from_iso8601,
+    'start_time', required=False, type=inputs.datetime_from_rfc822,
     location='json',
-    error='start_time must be an ISO 8601 timestamp'
+    error='start_time must be an RFC 822 timestamp'
 )
 settings_patch_req.add_argument(
-    'end_time', required=False, type=inputs.datetime_from_iso8601,
+    'end_time', required=False, type=inputs.datetime_from_rfc822,
     location='json',
-    error='end_time must be an ISO 8601 timestamp'
+    error='end_time must be an RFC 822 timestamp'
 )
 settings_patch_req.add_argument(
     'competition_name', required=False, type=str, location='json',

--- a/picoCTF-web/web/jsx/management-settings.jsx
+++ b/picoCTF-web/web/jsx/management-settings.jsx
@@ -94,8 +94,8 @@ const GeneralTab = React.createClass({
       enable_feedback: this.state.enable_feedback,
       competition_name: this.state.competition_name,
       competition_url: this.state.competition_url,
-      start_time: new Date(this.state.start_time).toISOString(),
-      end_time: new Date(this.state.end_time).toISOString(),
+      start_time: new Date(this.state.start_time).toUTCString(),
+      end_time: new Date(this.state.end_time).toUTCString(),
       max_team_size: this.state.max_team_size,
       username_blacklist: this.state.username_blacklist
     };


### PR DESCRIPTION
Currently GET outputs RFC822-formatted time while PATCH expects ISO8601-formatted time. This makes both of them use RFC822.

Fixes #361 