### PR TITLE
Clean up classroom management member list

### DIFF
--- a/picoCTF-web/web/jsx/classroom-management.jsx
+++ b/picoCTF-web/web/jsx/classroom-management.jsx
@@ -30,40 +30,15 @@ const MemberManagementItem = React.createClass({
       });
   },
 
-  // switchUserRole: (tid, role) ->
-  //   apiCall "POST", "/api/v1/group/teacher/role_switch", {gid: @props.gid, tid: tid, role: role}
-  //   .done ((resp) ->
-  //     apiNotify resp
-  //     @props.refresh()
-  //   ).bind this
-
   render() {
-    let userButton;
-    if (this.props.teacher) {
-      userButton = (
-        <Button bsStyle="success" className="btn-sq">
-          <Glyphicon glyph="user" bsSize="large" />
-          <p className="text-center">Teacher</p>
-        </Button>
-      );
-    } else {
-      userButton = (
-        <Button bsStyle="primary" className="btn-sq">
-          <Glyphicon glyph="user" bsSize="large" />
-          <p className="text-center">User</p>
-        </Button>
-      );
-    }
-
-    // if @props.teacher
-    //   switchUser = <Button onClick={@switchUserRole.bind(null, @props.tid, "member")}>Make Member</Button>
-    // else
-    //   switchUser = <Button onClick={@switchUserRole.bind(null, @props.tid, "teacher")}>Make Teacher</Button>
-
     return (
       <ListGroupItem>
         <Row className="row">
-          <Col xs={2}>{userButton}</Col>
+          <Col xs={2}>
+            <Button bsStyle="primary" className="btn-sq">
+              <Glyphicon glyph="user" bsSize="large" />
+            </Button>
+          </Col>
           <Col xs={6}>
             <h4>{this.props.team_name}</h4>
             <p>
@@ -72,7 +47,7 @@ const MemberManagementItem = React.createClass({
           </Col>
           <Col xs={4}>
             <ButtonGroup vertical={true}>
-              <Button onClick={this.removeTeam}>Remove User</Button>
+              <Button onClick={this.removeTeam}>Remove Team</Button>
             </ButtonGroup>
           </Col>
         </Row>


### PR DESCRIPTION
- Remove dead code for switching user roles
- Remove user type display that wasn't rendering correctly
- Change "Remove User" to "Remove Team" for accuracy
- Remove all user type checks, which didn't work anyway: teams don't have a teacher property