### PR TITLE
Require manual teacher role elevation in classrooms

### DIFF
--- a/picoCTF-web/api/apps/v1/schemas.py
+++ b/picoCTF-web/api/apps/v1/schemas.py
@@ -563,11 +563,11 @@ group_patch_req.add_argument(
     help='Updated settings object.'
 )
 
-# Group team removal request
-group_remove_team_req = reqparse.RequestParser()
-group_remove_team_req.add_argument(
+# Group team modification request
+group_modify_team_req = reqparse.RequestParser()
+group_modify_team_req.add_argument(
     'team_id', required=True, location='json', type=str,
-    help='ID of the team to remove.',
+    help='ID of the team to modify.',
     error='Team ID is required'
 )
 

--- a/picoCTF-web/api/apps/v1/team.py
+++ b/picoCTF-web/api/apps/v1/team.py
@@ -198,10 +198,7 @@ class GroupJoinResponse(Resource):
                     "for that classroom. Your team may not join this " +
                     "classroom at this time.".format(member["username"]), 403)
 
-        # Join the group as a teacher if the current user's account has
-        # teacher permissions
-        api.group.join_group(group['gid'], curr_user['tid'],
-                             teacher=(curr_user.get('teacher', False)))
+        api.group.join_group(group['gid'], curr_user['tid'])
         return jsonify({
             'success': True
         })

--- a/picoCTF-web/api/group.py
+++ b/picoCTF-web/api/group.py
@@ -100,7 +100,7 @@ def create_group(tid, group_name):
     db.groups.insert({
         "name": group_name,
         "owner": tid,
-        "teachers": [tid],
+        "teachers": [],
         "members": [],
         "settings": {
             "email_filter": [],

--- a/picoCTF-web/api/group.py
+++ b/picoCTF-web/api/group.py
@@ -100,7 +100,7 @@ def create_group(tid, group_name):
     db.groups.insert({
         "name": group_name,
         "owner": tid,
-        "teachers": [],
+        "teachers": [tid],
         "members": [],
         "settings": {
             "email_filter": [],

--- a/picoCTF-web/api/group.py
+++ b/picoCTF-web/api/group.py
@@ -189,6 +189,21 @@ def leave_group(gid, tid):
 
 
 @log_action
+def elevate_team(gid, tid):
+    """
+    Elevate a team within a group.
+
+    Args:
+        tid: the team id
+        gid: the group id to elevate to teacher status
+    """
+    db = api.db.get_conn()
+    db.groups.update({'gid': gid}, {'$pull': {"members": tid}})
+    db.groups.update({'gid': gid}, {'$push': {"teachers": tid}})
+    cache.invalidate(api.team.get_groups, tid)
+
+
+@log_action
 def delete_group(gid):
     """
     Delete a group.

--- a/picoCTF-web/api/stats.py
+++ b/picoCTF-web/api/stats.py
@@ -116,7 +116,7 @@ def get_group_scores(gid=None, name=None):
     Returns:
         A dictionary containing name, tid, and score
     """
-    key_args = {'gid': gid}
+    key_args = {'group_id': gid}
     scoreboard_cache = get_scoreboard_cache(**key_args)
     scoreboard_cache.clear()
 

--- a/picoCTF-web/api/user.py
+++ b/picoCTF-web/api/user.py
@@ -212,6 +212,7 @@ def add_user(params, batch_registration=False):
     # Additionally, invited users are automatically validated.
     user_is_teacher = params["usertype"] == "teacher"
     user_was_invited = False
+    join_group_as_teacher = False
     if params.get("rid", None):
         key = api.token.find_key_by_token("registration_token", params["rid"])
         if params.get("gid") != key["gid"]:
@@ -220,7 +221,7 @@ def add_user(params, batch_registration=False):
         if params["email"] != key["email"]:
             raise PicoException(
                 "Registration token email does not match the supplied one.")
-        user_is_teacher = key["teacher"]
+        join_group_as_teacher = key["teacher"]
         user_was_invited = True
         api.token.delete_token(key, "registration_token")
 
@@ -298,7 +299,7 @@ def add_user(params, batch_registration=False):
     # If gid was specified, add the newly created team to the group
     if params.get("gid", None):
         api.group.join_group(
-            params["gid"], tid, teacher=user_is_teacher)
+            params["gid"], tid, teacher=join_group_as_teacher)
 
     # If email verification is enabled and user wasn't invited, send
     # validation email

--- a/picoCTF-web/tests/api/functional/v1/test_team.py
+++ b/picoCTF-web/tests/api/functional/v1/test_team.py
@@ -377,5 +377,5 @@ def test_join_group(mongo_proc, client): # noqa (fixture)
     admin_team = db.users.find_one({
         'username': ADMIN_DEMOGRAPHICS['username']})['tid']
     group = db.groups.find_one({'name': 'newgroup'})
-    assert admin_team not in group['members']
-    assert admin_team in group['teachers']
+    assert admin_team in group['members']
+    assert admin_team not in group['teachers']

--- a/picoCTF-web/web/classroom.html
+++ b/picoCTF-web/web/classroom.html
@@ -46,6 +46,13 @@ startup_functions:
 </div>
 
 <script type="text/template" id="team-selection-template">
+    <% if (teams === undefined) { %>
+      <div class="row" style="margin-top: 10px">
+        <div class="col-sm-12">
+          <p>An existing teacher must promote your account before you can view this classroom.</p>
+        </div>
+      </div>
+    <% } else { %>
       <div class="row" style="margin-top: 10px">
           <div class="col-md-12">
             <div class="col-md-6">
@@ -260,6 +267,7 @@ startup_functions:
           <% }) %>
         </div>
       </div>
+    <% } %>
 </script>
 
 <script type="text/template" id="group-info-template">

--- a/picoCTF-web/web/jsx/classroom.jsx
+++ b/picoCTF-web/web/jsx/classroom.jsx
@@ -203,7 +203,13 @@ const deleteGroup = gid =>
       ).done(function(data) {
         apiNotify({ status: 1, message: "Successfully deleted classroom" });
         loadGroupInfo(true);
-      }),
+      })
+      .fail(jqXHR =>
+        apiNotify({
+          status: 0,
+          message: jqXHR.responseJSON.message
+        })
+      ),
     () => ga("send", "event", "Group", "DeleteGroup", "RejectPrompt")
   );
 

--- a/picoCTF-web/web/jsx/scoreboard.jsx
+++ b/picoCTF-web/web/jsx/scoreboard.jsx
@@ -82,6 +82,8 @@ const render_scoreboard = function(board_key, search) {
         scoreboard_sponsor: scoreboard_metadata[0].sponsor,
         scoreboard_logo: scoreboard_metadata[0].logo
       });
+    } else {
+       scoreboard_properties.scoreboard_name = $("ul#scoreboard-tabs li.active")[0].innerText;
     }
     let scoreboardContent = renderScoreboard(scoreboard_properties);
     $("#scoreboard-container").html(scoreboardContent).promise().then(
@@ -148,7 +150,11 @@ const attachSearchListeners = () => {
     clearTimeout(window.searchTimeout);
     window.searchTimeout = setTimeout(function () {
       let active_tab = $("#scoreboard-tabs li.active").data();
-      board_key = {'scoreboard_id': active_tab.sid};
+      if (active_tab.sid !== undefined) {
+        board_key = {'scoreboard_id': active_tab.sid};
+      } else if (active_tab.gid !== undefined) {
+        board_key = {'group_id': active_tab.gid};
+      }
       let searchValue = $("#search").val();
       render_scoreboard(board_key, searchValue);
     }, 250);


### PR DESCRIPTION
All users join groups (classrooms) in student roles, and can only be promoted to the teacher role by someone who already holds that role within the group or an administrator.

Slightly reworks the classroom management view, separating teachers into their own list.

Resolves #386 

