### PR TITLE
Fix uncaught exception when user tries to create/join self-team

### DIFF
--- a/picoCTF-web/api/apps/v1/team.py
+++ b/picoCTF-web/api/apps/v1/team.py
@@ -138,6 +138,9 @@ class TeamJoinResponse(Resource):
             raise PicoException('Teachers may not join teams!', 403)
         req = team_change_req.parse_args(strict=True)
 
+        if req['team_name'] == current_user['username']:
+            raise PicoException("Invalid team name", status_code=400)
+
         # Ensure that the team exists
         team = api.team.get_team(name=req['team_name'])
         if team is None:

--- a/picoCTF-web/api/apps/v1/team.py
+++ b/picoCTF-web/api/apps/v1/team.py
@@ -139,7 +139,7 @@ class TeamJoinResponse(Resource):
         req = team_change_req.parse_args(strict=True)
 
         if req['team_name'] == current_user['username']:
-            raise PicoException("Invalid team name", status_code=400)
+            raise PicoException("Invalid team name", status_code=409)
 
         # Ensure that the team exists
         team = api.team.get_team(name=req['team_name'])

--- a/picoCTF-web/api/apps/v1/teams.py
+++ b/picoCTF-web/api/apps/v1/teams.py
@@ -41,7 +41,7 @@ class TeamList(Resource):
             )
 
         if req['team_name'] == curr_user['username']:
-            raise PicoException("Invalid team name", status_code=400)
+            raise PicoException("Invalid team name", status_code=409)
 
         new_tid = api.team.create_and_join_new_team(
             req['team_name'],

--- a/picoCTF-web/api/apps/v1/teams.py
+++ b/picoCTF-web/api/apps/v1/teams.py
@@ -40,6 +40,9 @@ class TeamList(Resource):
                 "()+-,#'&!?", status_code=400
             )
 
+        if req['team_name'] == curr_user['username']:
+            raise PicoException("Invalid team name", status_code=400)
+
         new_tid = api.team.create_and_join_new_team(
             req['team_name'],
             req['team_password'],

--- a/picoCTF-web/api/user.py
+++ b/picoCTF-web/api/user.py
@@ -246,7 +246,7 @@ def add_user(params, batch_registration=False):
     # Create a team for the new user and set its count to 1
     tid = api.team.create_team({
         "team_name": params["username"],
-        "password": api.common.token(),
+        "password": api.common.hash_password("-"),
         "affiliation": params["affiliation"],
     })
     db.teams.update_one(


### PR DESCRIPTION
- Raise exception on join/create when team_name == username
- Create self-teams with invalid (too short) password that are valid utf-encoded