### PR TITLE
Tune nginx config

### DIFF
--- a/ansible/roles/pico-shell/templates/shell.nginx.j2
+++ b/ansible/roles/pico-shell/templates/shell.nginx.j2
@@ -14,7 +14,7 @@ server {
     listen       80;
 {% endif %}
 
-    more_clear_headers Server;
+    server_tokens off;
     more_clear_headers Strict-Transport-Security;
 
     location /shell {

--- a/ansible/roles/pico-web/files/nginx.conf
+++ b/ansible/roles/pico-web/files/nginx.conf
@@ -1,0 +1,86 @@
+user www-data;
+worker_processes auto;
+worker_rlimit_nofile 65535;
+pid /run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
+
+events {
+        worker_connections 1536;
+	# multi_accept on;
+}
+
+http {
+
+	##
+	# Basic Settings
+	##
+
+	sendfile on;
+	tcp_nopush on;
+	tcp_nodelay on;
+	keepalive_timeout 65;
+	types_hash_max_size 2048;
+	# server_tokens off;
+
+	# server_names_hash_bucket_size 64;
+	# server_name_in_redirect off;
+
+	include /etc/nginx/mime.types;
+	default_type application/octet-stream;
+
+	##
+	# SSL Settings
+	##
+
+	ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
+	ssl_prefer_server_ciphers on;
+
+	##
+	# Logging Settings
+	##
+
+	access_log /var/log/nginx/access.log;
+	error_log /var/log/nginx/error.log;
+
+	##
+	# Gzip Settings
+	##
+
+	gzip on;
+
+	# gzip_vary on;
+	# gzip_proxied any;
+	# gzip_comp_level 6;
+	# gzip_buffers 16 8k;
+	# gzip_http_version 1.1;
+	# gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+	##
+	# Virtual Host Configs
+	##
+
+	include /etc/nginx/conf.d/*.conf;
+	include /etc/nginx/sites-enabled/*;
+}
+
+
+#mail {
+#	# See sample authentication script at:
+#	# http://wiki.nginx.org/ImapAuthenticateWithApachePhpScript
+# 
+#	# auth_http localhost/auth.php;
+#	# pop3_capabilities "TOP" "USER";
+#	# imap_capabilities "IMAP4rev1" "UIDPLUS";
+# 
+#	server {
+#		listen     localhost:110;
+#		protocol   pop3;
+#		proxy      on;
+#	}
+# 
+#	server {
+#		listen     localhost:143;
+#		protocol   imap;
+#		proxy      on;
+#	}
+#}

--- a/ansible/roles/pico-web/files/override.conf
+++ b/ansible/roles/pico-web/files/override.conf
@@ -1,0 +1,2 @@
+[Service]
+LimitNOFILE=65535

--- a/ansible/roles/pico-web/tasks/nginx.yml
+++ b/ansible/roles/pico-web/tasks/nginx.yml
@@ -2,6 +2,32 @@
 # Playbook that configures nginx for picoCTF-web
 # This is the base picoCTF web nginx configuration
 
+- name: Configure nginx
+  copy:
+    src: nginx.conf
+    dest: /etc/nginx/nginx.conf
+    owner: root
+    group: root
+    mode: 0644
+  notify :
+    - nginx restart
+
+- name: Add nginx.service override directory
+  file:
+    path: /etc/systemd/system/nginx.service.d/
+    state: directory
+    mode: 0755
+
+- name: Copy NOLIMIT override file
+  copy:
+    src: override.conf
+    dest: /etc/systemd/system/nginx.service.d/override.conf
+    owner: root
+    group: root
+    mode: 0644
+  notify :
+    - nginx restart
+
 - name: Add picoCTF site configuration to nginx
   template: 
     src: ctf.nginx.j2

--- a/ansible/roles/pico-web/templates/ctf.nginx.j2
+++ b/ansible/roles/pico-web/templates/ctf.nginx.j2
@@ -6,7 +6,7 @@ server {
         root  {{ pico_http_dir }};
 
         {% if enable_web_ssl | bool -%}
-        listen       443 ssl http2;
+        listen       443 ssl http2 reuseport;
 
         ssl_certificate  /etc/ssl/certs/ssl-pico.chained.crt;
         ssl_certificate_key /etc/ssl/private/ssl-pico.key;
@@ -23,11 +23,15 @@ server {
 
         client_max_body_size 15k;
 
+        open_file_cache max=100;
+        open_file_cache_valid 60s;
+        open_file_cache_errors off;
+
         error_page 404  = /404.html;
         error_page 401  = /401.html;
 
-        # Block server info in header
-        more_clear_headers Server;
+        # Block server info in headers and errors
+        server_tokens off;
 
         # Prevent clickjacking
         add_header X-Frame-Options "SAMEORIGIN";
@@ -57,6 +61,9 @@ server {
         location ~ /api/ {
             # allows internal network requests from shell_server (pam related)
             proxy_set_header Host {{ flask_app_server_name}};
+
+            proxy_buffer_size 2k;
+            proxy_buffers 24 4k;
 
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/ansible/roles/pico-web/templates/gunicorn.service.j2
+++ b/ansible/roles/pico-web/templates/gunicorn.service.j2
@@ -13,6 +13,7 @@ ExecStart={{ virtualenv_dir }}/bin/gunicorn --max-requests 2000 --pid /run/gunic
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID
 PrivateTmp=true
+LimitNOFILE=65535
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- Increase worker nofile to 65535, connections to twice the 768 default
- server_tokens off instead of removing Server header
- Add reuseport for nginx 443 listener
- Cache static files on web server for 60s
- Config systemd for LimitNOFILE for nginx and gunicorn
- Decrease proxy header buffer size from 4k to 2k
- Increase proxy_buffers from 8 to 24 based on largest pico2019 non-admin request payload of 80KB from `/problems`