### PR TITLE
Reduce the payload of problems.find() queries with optional filter

### DIFF
--- a/picoCTF-web/api/apps/v1/problems.py
+++ b/picoCTF-web/api/apps/v1/problems.py
@@ -105,9 +105,7 @@ class ProblemList(Resource):
             # Additionally, show only fields from the assigned instance.
             problems = [api.problem.filter_problem_instances(
                             p, api.user.get_user()['tid']) for p in problems]
-
-        # Strip out any system properties for non-admin users
-        if not is_admin:
+            # Strip out admin-only fields
             problems = api.problem.sanitize_problem_data(problems)
 
         # Handle the count_only param

--- a/picoCTF-web/api/apps/v1/problems.py
+++ b/picoCTF-web/api/apps/v1/problems.py
@@ -243,7 +243,8 @@ class ProblemWalkthrough(Resource):
     def get(self, problem_id):
         """Get the walkthrough for a problem, if unlocked."""
         uid = api.user.get_user()['uid']
-        problem = api.problem.get_problem(problem_id)
+        problem = api.problem.get_problem(problem_id,
+                                          {"pid": 1, "walkthrough": 1})
         if problem is None:
             raise PicoException('Problem not found', 404)
         if problem.get('walkthrough', None) is None:
@@ -270,7 +271,8 @@ class ProblemWalkthroughUnlockResponse(Resource):
     def get(self, problem_id):
         """Spend tokens to unlock the walkthrough for a problem."""
         curr_user = api.user.get_user()
-        problem = api.problem.get_problem(problem_id)
+        problem = api.problem.get_problem(problem_id,
+                                          {"score": 1, "walkthrough": 1})
         if problem is None:
             raise PicoException('Problem not found', 404)
         if problem.get('walkthrough', None) is None:

--- a/picoCTF-web/api/problem_feedback.py
+++ b/picoCTF-web/api/problem_feedback.py
@@ -62,7 +62,7 @@ def upsert_feedback(pid, feedback):
     uid = api.user.get_user()['uid']
 
     # Make sure the problem actually exists.
-    if not api.problem.get_problem(pid):
+    if not api.problem.get_problem(pid, {"pid": 1}):
         raise PicoException('Problem not found', 404)
 
     team = api.user.get_team(uid=uid)

--- a/picoCTF-web/api/submissions.py
+++ b/picoCTF-web/api/submissions.py
@@ -92,7 +92,8 @@ def submit_key(tid, pid, key, method, uid, ip=None):
             'ip': ip,
             'key': key,
             'method': method,
-            'category': api.problem.get_problem(pid)['category'],
+            'category': api.problem.get_problem(pid, {"category": 1})[
+                'category'],
             'correct': correct,
         })
 


### PR DESCRIPTION
- Reduces get_solved_problems memoized value by orders of magnitude
- Resolves #405
- Likely reduces memory bloat of worker threads doing problem/score
related operations