### PR TITLE
Shared submissions refactor

### DIFF
--- a/picoCTF-web/api/apps/v1/groups.py
+++ b/picoCTF-web/api/apps/v1/groups.py
@@ -317,7 +317,7 @@ class FlagSharingInfo(Resource):
             )
 
         return jsonify(
-            api.stats.check_invalid_instance_submissions(group['gid']))
+            api.stats.check_shared_group_submissions(group['gid']))
 
 
 @ns.response(200, 'Success')

--- a/picoCTF-web/api/db.py
+++ b/picoCTF-web/api/db.py
@@ -122,4 +122,6 @@ def get_conn():
         __connection.tokens.create_index("tokens.email_verification")
         __connection.tokens.create_index("tokens.password_reset")
 
+        __connection.shared_submissions.create_index("tid")
+
     return __connection

--- a/picoCTF-web/api/team.py
+++ b/picoCTF-web/api/team.py
@@ -6,6 +6,7 @@ from voluptuous import Length, Required, Schema
 import api
 from api import cache, check, log_action, PicoException
 from api.cache import memoize
+from api.stats import check_shared_submissions
 
 PROBLEMSOLVED_FILTER = ['category', 'name', 'score', 'solve_time']
 
@@ -275,10 +276,7 @@ def get_team_information(tid):
         "usertype": member["usertype"],
     } for member in get_team_members(tid=tid, show_disabled=False)]
     team_info["progression"] = api.stats.get_score_progression(tid=tid)
-    team_info["flagged_submissions"] = [
-        sub for sub in api.stats.check_invalid_instance_submissions()
-        if sub['tid'] == tid
-    ]
+    team_info["flagged_submissions"] = check_shared_submissions(tid=tid)
     team_info["max_team_size"] = api.config.get_settings()["max_team_size"]
 
     if api.config.get_settings()["achievements"]["enable_achievements"]:

--- a/picoCTF-web/daemons/cache_stats.py
+++ b/picoCTF-web/daemons/cache_stats.py
@@ -3,7 +3,7 @@
 
 import api
 import api.group
-from api.stats import (check_invalid_instance_submissions, get_all_team_scores,
+from api.stats import (collect_shared_submissions, get_all_team_scores,
                        get_group_scores, get_problem_solves,
                        get_registration_count,
                        get_top_teams_score_progressions)
@@ -58,8 +58,8 @@ def run():
             print(problem["name"],
                   cache(get_problem_solves, problem["pid"]))
 
-        print("Caching invalid instance submissions...")
-        cache(check_invalid_instance_submissions)
+        print("Collecting shared flag submissions...")
+        collect_shared_submissions()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Instead of large memoized value that is filtered by each `/team` call,
enable `tid` lookup with a shared_submissions collection that is
regularly purged and rebuilt