### PR TITLE
Refactor suspicious submissions

### DIFF
--- a/picoCTF-web/api/apps/v1/groups.py
+++ b/picoCTF-web/api/apps/v1/groups.py
@@ -299,31 +299,6 @@ class RemoveTeamResponse(Resource):
 @ns.response(401, 'Not logged in')
 @ns.response(403, 'Permission denied')
 @ns.response(404, 'Classroom not found')
-@ns.route('/<string:group_id>/flag_sharing')
-class FlagSharingInfo(Resource):
-    """Get flag sharing statistics for a specific group."""
-
-    def get(self, group_id):
-        """Get flag sharing statistics for a specific group."""
-        group = api.group.get_group(gid=group_id)
-        if not group:
-            raise PicoException('Classroom not found', 404)
-
-        curr_user = api.user.get_user()
-        if (curr_user['tid'] not in (group['teachers'] + [group['owner']])
-                and not curr_user['admin']):
-            raise PicoException(
-                'You do not have permission to view these statistics.', 403
-            )
-
-        return jsonify(
-            api.stats.check_invalid_instance_submissions(group['gid']))
-
-
-@ns.response(200, 'Success')
-@ns.response(401, 'Not logged in')
-@ns.response(403, 'Permission denied')
-@ns.response(404, 'Classroom not found')
 @ns.route('/<string:group_id>/invite')
 class InviteResponse(Resource):
     """Send an email invite to join this team."""

--- a/picoCTF-web/api/db.py
+++ b/picoCTF-web/api/db.py
@@ -91,6 +91,7 @@ def get_conn():
         __connection.submissions.create_index([("pid", 1), ("correct", 1)])
         __connection.submissions.create_index("uid")
         __connection.submissions.create_index("tid")
+        __connection.submissions.create_index("suspicious")
 
         __connection.teams.create_index(
             "team_name", unique=True, name="unique team_names")

--- a/picoCTF-web/api/stats.py
+++ b/picoCTF-web/api/stats.py
@@ -362,37 +362,6 @@ def get_top_teams_score_progressions(
     return [output_item(team_item) for team_item in team_items]
 
 
-@memoize
-def check_invalid_instance_submissions(gid=None):
-    """Get submissions of keys for the wrong problem instance."""
-    db = api.db.get_conn()
-    shared_key_submissions = []
-
-    group = None
-    if gid is not None:
-        group = api.group.get_group(gid=gid)
-
-    for problem in api.problem.get_all_problems(show_disabled=True):
-        valid_keys = [instance['flag'] for instance in problem['instances']]
-        incorrect_submissions = db.submissions.find({
-            'pid': problem['pid'],
-            'correct': False
-        }, {"_id": 0})
-        for submission in incorrect_submissions:
-            if submission['key'] in valid_keys:
-                # make sure that the key is still invalid
-                if not api.submissions.grade_problem(
-                        submission['pid'], submission['key'],
-                        tid=submission['tid']):
-                    if group is None or submission['tid'] in group['members']:
-                        submission['username'] = api.user.get_user(
-                            uid=submission['uid'])['username']
-                        submission["problem_name"] = problem["name"]
-                        shared_key_submissions.append(submission)
-
-    return shared_key_submissions
-
-
 # Stored by the cache_stats daemon.
 @memoize
 def get_registration_count():

--- a/picoCTF-web/api/team.py
+++ b/picoCTF-web/api/team.py
@@ -275,10 +275,8 @@ def get_team_information(tid):
         "usertype": member["usertype"],
     } for member in get_team_members(tid=tid, show_disabled=False)]
     team_info["progression"] = api.stats.get_score_progression(tid=tid)
-    team_info["flagged_submissions"] = [
-        sub for sub in api.stats.check_invalid_instance_submissions()
-        if sub['tid'] == tid
-    ]
+    team_info["flagged_submissions"] = \
+        api.submissions.get_suspicious_submissions(tid)
     team_info["max_team_size"] = api.config.get_settings()["max_team_size"]
 
     if api.config.get_settings()["achievements"]["enable_achievements"]:

--- a/picoCTF-web/daemons/cache_stats.py
+++ b/picoCTF-web/daemons/cache_stats.py
@@ -3,7 +3,7 @@
 
 import api
 import api.group
-from api.stats import (check_invalid_instance_submissions, get_all_team_scores,
+from api.stats import (get_all_team_scores,
                        get_group_scores, get_problem_solves,
                        get_registration_count,
                        get_top_teams_score_progressions)
@@ -57,9 +57,6 @@ def run():
         for problem in api.problem.get_all_problems():
             print(problem["name"],
                   cache(get_problem_solves, problem["pid"]))
-
-        print("Caching invalid instance submissions...")
-        cache(check_invalid_instance_submissions)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Checks submissions for suspiciousness (are they incorrect, but have the correct flag for another team's instance?) at submission time and stores this as a property of the submission.

Removes the need for a recurring check across all submissions. After all, a submission can only be considered suspicious based on the instances that exist at the time of that submission.

Removes the `groups/<gid>/flag_sharing` call, which was not used by the frontend.