### PR TITLE
Shell manager undeployment/update changes

### DIFF
--- a/picoCTF-shell/hacksport/install.py
+++ b/picoCTF-shell/hacksport/install.py
@@ -28,7 +28,7 @@ from hacksport.deploy import generate_staging_directory
 logger = logging.getLogger(__name__)
 
 
-def install_problem(problem_path):
+def install_problem(problem_path, allow_reinstall=False):
     """
     Install a problem from a source directory.
 
@@ -36,8 +36,9 @@ def install_problem(problem_path):
         problem_path: path to the problem source directory
     """
     problem_obj = get_problem(problem_path)
-    if os.path.isdir(get_problem_root_hashed(problem_obj, absolute=True)):
-        logger.error(f"Problem {problem_obj['unique_name']} is already installed")
+    if (os.path.isdir(get_problem_root_hashed(problem_obj, absolute=True)) and
+            not allow_reinstall):
+        logger.error(f"Problem {problem_obj['unique_name']} is already installed. You may specify --reinstall to reinstall an updated version from the specified directory.")
         return
     logger.info(f"Installing problem {problem_obj['unique_name']}...")
 
@@ -98,7 +99,7 @@ def install_problems(args):
         problem_paths.extend(find_problem_sources(base_path))
 
     for problem_path in problem_paths:
-        install_problem(problem_path)
+        install_problem(problem_path, (args.reinstall is not None))
 
 
 def uninstall_problem(problem_name):

--- a/picoCTF-shell/shell_manager/run.py
+++ b/picoCTF-shell/shell_manager/run.py
@@ -40,6 +40,11 @@ def main():
     install_parser.add_argument(
         "problem_paths", nargs="*", type=str,
         help="paths to problem source directories")
+    install_parser.add_argument(
+        "--reinstall",
+        action="store_true",
+        default=None,
+        help="reinstall over an existing version of this problem")
     install_parser.set_defaults(func=install_problems)
 
     uninstall_parser = subparsers.add_parser(


### PR DESCRIPTION
- Hopefully fixes instance undeployment by killing processes associated with an instance port before attempting to remove instance users, and skipping steps that error

- Allows for problem reinstallation with `--reinstall` flag, which avoids having the problem wiped from the port map via `uninstall`. Instances need to be un- and re- deployed after reinstallation to use the updated source files.