### PR TITLE
Trim whitespace on various fields

### DIFF
--- a/picoCTF-web/api/apps/v1/groups.py
+++ b/picoCTF-web/api/apps/v1/groups.py
@@ -46,6 +46,8 @@ class GroupList(Resource):
     def post(self):
         """Create a new group."""
         req = group_req.parse_args(strict=True)
+        req['name'] = req['name'].strip()
+
         curr_user = api.user.get_user()
 
         # Don't create group if teacher already has one with same name
@@ -301,13 +303,13 @@ class RemoveTeamResponse(Resource):
 @ns.response(404, 'Classroom not found')
 @ns.route('/<string:group_id>/invite')
 class InviteResponse(Resource):
-    """Send an email invite to join this team."""
+    """Send an email invite to join this group."""
 
     @rate_limit(limit=1, duration=30)
     @ns.response(429, 'Too many requests, slow down!')
     @ns.expect(group_invite_req)
     def post(self, group_id):
-        """Send an email invite to join this team."""
+        """Send an email invite to join this group."""
         req = group_invite_req.parse_args(strict=True)
         group = api.group.get_group(gid=group_id)
         if not group:

--- a/picoCTF-web/api/apps/v1/team.py
+++ b/picoCTF-web/api/apps/v1/team.py
@@ -140,6 +140,8 @@ class TeamJoinResponse(Resource):
             raise PicoException('Teachers may not join teams!', 403)
         req = team_change_req.parse_args(strict=True)
 
+        req['team_name'] = req['team_name'].strip()
+
         if req['team_name'] == current_user['username']:
             raise PicoException("Invalid team name", status_code=409)
 

--- a/picoCTF-web/api/apps/v1/team.py
+++ b/picoCTF-web/api/apps/v1/team.py
@@ -173,6 +173,8 @@ class GroupJoinResponse(Resource):
     def post(self):
         """Add your current team to a group."""
         req = join_group_req.parse_args(strict=True)
+        req['group_name'] = req['group_name'].strip()
+
         curr_user = api.user.get_user()
 
         # Make sure the specified group and owner exist

--- a/picoCTF-web/api/apps/v1/teams.py
+++ b/picoCTF-web/api/apps/v1/teams.py
@@ -32,6 +32,7 @@ class TeamList(Resource):
             raise PicoException(
                 'Teachers may not create teams', 403
             )
+        req['team_name'] = req['team_name'].strip()
         if not all([
                 c in string.digits + string.ascii_lowercase + " ()+-,#'&!?"
                 for c in req['team_name'].lower()]):

--- a/picoCTF-web/api/apps/v1/users.py
+++ b/picoCTF-web/api/apps/v1/users.py
@@ -63,6 +63,9 @@ class UserList(Resource):
                 'Usernames must be alphanumeric.', status_code=400
             )
 
+        # Clean up input data
+        req['affiliation'] = req['affiliation'].strip()
+
         # Attempt to create the user
         uid = api.user.add_user(req)
 
@@ -119,7 +122,7 @@ class UserDataExport(Resource):
 
     @require_admin
     def get(self, user_id):
-        """Export all data of a given user."""        
+        """Export all data of a given user."""
         user_data = api.user.get_user(uid=user_id)
         if not user_data:
             raise PicoException('User not found', status_code=404)
@@ -142,7 +145,7 @@ class UserSearch(Resource):
     @require_admin
     @ns.expect(user_search_req)
     def post(self):
-        """Search for a given user."""        
+        """Search for a given user."""
         req = user_search_req.parse_args(strict=True)
 
         if req["field"] == "Email":


### PR DESCRIPTION
Strips beginning and trailing whitespace from team names, group names, batch registration fields, and user affiliations.

Resolves #417 
Resolves #427 

Not backportable into 2019 deployment due to existing team/group names with trailing spaces (these teams/groups would become unjoinable)