### PR TITLE
Conditional removal of team members

### DIFF
--- a/picoCTF-web/api/apps/v1/team.py
+++ b/picoCTF-web/api/apps/v1/team.py
@@ -11,8 +11,9 @@ from .schemas import (join_group_req, score_progression_req, team_change_req,
 ns = Namespace('team', description="Information about the current user's team")
 
 TEAMDATA_FILTER = ['achievements', 'affiliation', 'allow_ineligible_members',
-                   'eligibilities', 'max_team_size', 'members', 'progression',
-                   'score', 'size', 'solved_problems', 'team_name', 'tid']
+                   'creator', 'eligibilities', 'max_team_size', 'members',
+                   'progression', 'score', 'size', 'solved_problems',
+                   'team_name', 'tid']
 
 TEAMMEMBER_FILTER = ['affiliation', 'can_leave', 'country', 'uid', 'username',
                      'usertype']

--- a/picoCTF-web/api/apps/v1/team.py
+++ b/picoCTF-web/api/apps/v1/team.py
@@ -14,7 +14,8 @@ TEAMDATA_FILTER = ['achievements', 'affiliation', 'allow_ineligible_members',
                    'eligibilities', 'max_team_size', 'members', 'progression',
                    'score', 'size', 'solved_problems', 'team_name', 'tid']
 
-TEAMMEMBER_FILTER = ['affiliation', 'country', 'username', 'usertype']
+TEAMMEMBER_FILTER = ['affiliation', 'can_leave', 'country', 'uid', 'username',
+                     'usertype']
 
 
 @ns.route('')

--- a/picoCTF-web/api/apps/v1/team.py
+++ b/picoCTF-web/api/apps/v1/team.py
@@ -1,10 +1,9 @@
 """Endpoints related to the current user's team."""
+import api
+from api import (block_before_competition, check_csrf, PicoException,
+                 rate_limit, require_login)
 from flask import jsonify
 from flask_restplus import Namespace, Resource
-
-import api
-from api import (PicoException, block_before_competition, check_csrf,
-                 rate_limit, require_login)
 
 from .schemas import (join_group_req, score_progression_req, team_change_req,
                       team_patch_req, update_team_password_req)
@@ -207,3 +206,23 @@ class GroupJoinResponse(Resource):
         return jsonify({
             'success': True
         })
+
+
+@ns.route('/members/<string:user_id>')
+class MemberRemovalResponse(Resource):
+    """Remove a member from the user's current team."""
+
+    @require_login
+    @ns.response(200, 'Success')
+    @ns.response(400, 'Error parsing request')
+    @ns.response(401, 'Not logged in')
+    @ns.response(403, 'Team member cannot be removed')
+    @ns.response(404, 'Team member does not exist')
+    def delete(self, user_id):
+        """
+        Remove a member from the team.
+
+        Only works if the user has not yet submitted any flags.
+        """
+        api.team.remove_member(api.user.get_user()['tid'], user_id)
+        return jsonify({'success': True})

--- a/picoCTF-web/api/apps/v1/user.py
+++ b/picoCTF-web/api/apps/v1/user.py
@@ -13,7 +13,7 @@ ns = Namespace('user', description='Authentication and information about ' +
                                    'current user')
 
 USERDATA_FILTER = ['admin', 'extdata', 'completed_minigames', 'logged_in',
-                   'teacher', 'tid', 'tokens', 'unlocked_walkthroughs',
+                   'teacher', 'tid', 'tokens', 'uid', 'unlocked_walkthroughs',
                    'username', 'verified']
 
 @ns.route('')

--- a/picoCTF-web/api/team.py
+++ b/picoCTF-web/api/team.py
@@ -487,6 +487,7 @@ def is_teacher_team(tid):
         return False
 
 
+@log_action
 def delete_team(tid):
     """Scrub all traces of a team."""
     db = api.db.get_conn()
@@ -498,6 +499,7 @@ def delete_team(tid):
     api.cache.invalidate(api.team.get_groups, tid)
 
 
+@log_action
 def remove_member(tid, uid):
     """
     Move the specified member back to their self-team.

--- a/picoCTF-web/api/team.py
+++ b/picoCTF-web/api/team.py
@@ -507,24 +507,24 @@ def remove_member(tid, uid):
     """
     team = get_team(tid)
     curr_user_uid = api.user.get_user()['uid']
-    curr_user_is_creator = (curr_user_uid == team['creator'])
+    curr_user_is_creator = (curr_user_uid == team.get('creator'))
 
-    if (not curr_user_is_creator and uid != curr_user_uid):
+    if not curr_user_is_creator and uid != curr_user_uid:
         raise PicoException(
             "Only the team creator can kick other members.", status_code=403
         )
 
-    if (uid not in get_team_uids(tid)):
+    if uid not in get_team_uids(tid):
         raise PicoException(
             "Specified user is not a member of this team.", status_code=404)
 
-    if (api.user.get_user(uid=uid)['username'] == team['team_name']):
+    if api.user.get_user(uid=uid)['username'] == team['team_name']:
         raise PicoException(
             "Cannot remove self from default team", status_code=403
         )
 
-    if (not api.user.can_leave_team(uid)):
-        if (curr_user_is_creator and curr_user_uid == uid):
+    if not api.user.can_leave_team(uid):
+        if curr_user_is_creator and curr_user_uid == uid:
             raise PicoException(
                 "Team creator must be the only remaining member in order " +
                 "to leave.", status_code=403
@@ -559,7 +559,7 @@ def remove_member(tid, uid):
 
     # Delete the custom team if no members remain
     remaining_team_size = db.teams.find_one({"tid": tid}, {"size": 1})['size']
-    if (remaining_team_size < 1):
+    if remaining_team_size < 1:
         delete_team(tid)
 
     # Copy any acquired group memberships back to the self-team

--- a/picoCTF-web/api/team.py
+++ b/picoCTF-web/api/team.py
@@ -273,6 +273,7 @@ def get_team_information(tid):
         "affiliation": member.get("affiliation", "None"),
         "country": member["country"],
         "usertype": member["usertype"],
+        "can_leave": api.user.can_leave_team(member['uid'])
     } for member in get_team_members(tid=tid, show_disabled=False)]
     team_info["progression"] = api.stats.get_score_progression(tid=tid)
     team_info["flagged_submissions"] = \
@@ -499,7 +500,7 @@ def remove_member(tid, uid):
         raise PicoException(
             "Specified user is not a member of this team.",
             status_code=404)
-    if (len(api.submissions.get_submissions(uid=uid, correctness=True)) > 0):
+    if (not api.user.can_leave_team(uid)):
         raise PicoException(
             "This team member has submitted at least one valid answer and " +
             "cannot be removed.", status_code=403

--- a/picoCTF-web/api/team.py
+++ b/picoCTF-web/api/team.py
@@ -513,7 +513,7 @@ def remove_member(tid, uid):
 
     if not curr_user_is_creator and uid != curr_user_uid:
         raise PicoException(
-            "Only the team creator can kick other members.", status_code=403
+            "Only the team captain can kick other members.", status_code=403
         )
 
     if uid not in get_team_uids(tid):
@@ -528,7 +528,7 @@ def remove_member(tid, uid):
     if not api.user.can_leave_team(uid):
         if curr_user_is_creator and curr_user_uid == uid:
             raise PicoException(
-                "Team creator must be the only remaining member in order " +
+                "Team captain must be the only remaining member in order " +
                 "to leave.", status_code=403
             )
         else:

--- a/picoCTF-web/api/team.py
+++ b/picoCTF-web/api/team.py
@@ -514,7 +514,7 @@ def remove_member(tid, uid):
             "This team member has submitted at least one valid answer and " +
             "cannot be removed.", status_code=403
         )
-    if (api.user.get_user(uid)['username'] ==
+    if (api.user.get_user(uid=uid)['username'] ==
             api.team.get_team(tid)['team_name']):
         raise PicoException(
             "Cannot remove self from default team", status_code=403

--- a/picoCTF-web/api/user.py
+++ b/picoCTF-web/api/user.py
@@ -679,3 +679,10 @@ def rate_limit(limit=5, duration=60, by_ip=False, allow_bypass=False):
                 raise PicoException(limit_msg, 429)
         return wrapper
     return decorator
+
+
+def can_leave_team(uid):
+    """Determine whether a user is eligible to leave their current team."""
+    if (len(api.submissions.get_submissions(uid=uid, correctness=True)) > 0):
+        return False
+    return True

--- a/picoCTF-web/api/user.py
+++ b/picoCTF-web/api/user.py
@@ -683,6 +683,10 @@ def rate_limit(limit=5, duration=60, by_ip=False, allow_bypass=False):
 
 def can_leave_team(uid):
     """Determine whether a user is eligible to leave their current team."""
-    if (len(api.submissions.get_submissions(uid=uid, correctness=True)) > 0):
+    current_tid = get_user(uid=uid)['tid']
+    current_team = api.team.get_team(current_tid)
+    if (current_team['creator'] == uid and current_team['size'] != 1):
+        return False
+    if (len(api.submissions.get_submissions(uid=uid)) > 0):
         return False
     return True

--- a/picoCTF-web/api/user.py
+++ b/picoCTF-web/api/user.py
@@ -685,10 +685,10 @@ def can_leave_team(uid):
     """Determine whether a user is eligible to leave their current team."""
     current_user = get_user(uid=uid)
     current_team = api.team.get_team(current_user['tid'])
-    if (current_team['team_name'] == current_user['username']):
+    if current_team['team_name'] == current_user['username']:
         return False
-    if (current_team['creator'] == uid and current_team['size'] != 1):
+    if current_team['creator'] == uid and current_team['size'] != 1:
         return False
-    if (len(api.submissions.get_submissions(uid=uid)) > 0):
+    if len(api.submissions.get_submissions(uid=uid)) > 0:
         return False
     return True

--- a/picoCTF-web/api/user.py
+++ b/picoCTF-web/api/user.py
@@ -683,8 +683,10 @@ def rate_limit(limit=5, duration=60, by_ip=False, allow_bypass=False):
 
 def can_leave_team(uid):
     """Determine whether a user is eligible to leave their current team."""
-    current_tid = get_user(uid=uid)['tid']
-    current_team = api.team.get_team(current_tid)
+    current_user = get_user(uid=uid)
+    current_team = api.team.get_team(current_user['tid'])
+    if (current_team['team_name'] == current_user['username']):
+        return False
     if (current_team['creator'] == uid and current_team['size'] != 1):
         return False
     if (len(api.submissions.get_submissions(uid=uid)) > 0):

--- a/picoCTF-web/web/jsx/profile.jsx
+++ b/picoCTF-web/web/jsx/profile.jsx
@@ -232,14 +232,31 @@ const TeamManagementForm = React.createClass({
     }
   },
 
+  removeMember(e) {
+    e.preventDefault();
+    apiCall("DELETE", "/api/v1/team/members/" + e.target.dataset.uid)
+    .done(function() {
+      document.location.href = "/profile";
+    })
+    .fail(jqXHR =>
+      apiNotify({ status: 0, message: jqXHR.responseJSON.message })
+    );
+  },
+
   listMembers() {
     return this.state.team["members"].map((member, i) => (
-      <li key={i}>
+      <li key={i} style={{marginBottom: '10px'}}>
         {member.username} (
         <span className="capitalize">
-          {member.usertype} - {member.country}
+          {member.usertype} - {member.country}) {
+            member.can_leave && (
+              <Button
+                style={{marginLeft: '5px'}}
+                data-uid={member.uid}
+                onClick={this.removeMember}
+              >{member.uid === this.state.user.uid ? "Leave Team" : "Kick Member"}</Button>
+            )}
         </span>
-        )
       </li>
     ));
   },
@@ -282,6 +299,7 @@ const TeamManagementForm = React.createClass({
               <strong>Members</strong> ({this.state.team.members.length}/
               {this.state.team.max_team_size}):
             </p>
+            <p><i>Members who have contributed to the team's score cannot be removed.</i></p>
             <ul>{this.listMembers()}</ul>
             <hr />
             <form onSubmit={this.onTeamPasswordChange}>

--- a/picoCTF-web/web/jsx/profile.jsx
+++ b/picoCTF-web/web/jsx/profile.jsx
@@ -249,12 +249,12 @@ const TeamManagementForm = React.createClass({
         {member.username} (
         <span className="capitalize">
           {member.usertype} - {member.country}) {
-            member.can_leave && (
+            (this.state.user.uid === this.state.team['creator'] || member.uid == this.state.user.uid) && member.can_leave && (
               <Button
                 style={{marginLeft: '5px'}}
                 data-uid={member.uid}
                 onClick={this.removeMember}
-              >{member.uid === this.state.user.uid ? "Leave Team" : "Kick Member"}</Button>
+              >{member.uid === this.state.user.uid ? (this.state.user.uid === this.state.team['creator'] ? "Delete Team" : "Leave Team") : "Kick Member"}</Button>
             )}
         </span>
       </li>
@@ -299,7 +299,11 @@ const TeamManagementForm = React.createClass({
               <strong>Members</strong> ({this.state.team.members.length}/
               {this.state.team.max_team_size}):
             </p>
-            <p><i>Members who have contributed to the team's score cannot be removed.</i></p>
+            {this.state.user.uid === this.state.team.creator &&
+              (<div>
+                <p><i>Members who have submitted flags cannot be removed.</i></p>
+                <p><i>All other members must be removed in order to delete the team.</i></p>
+              </div>)}
             <ul>{this.listMembers()}</ul>
             <hr />
             <form onSubmit={this.onTeamPasswordChange}>

--- a/picoCTF-web/web/jsx/profile.jsx
+++ b/picoCTF-web/web/jsx/profile.jsx
@@ -246,6 +246,9 @@ const TeamManagementForm = React.createClass({
   listMembers() {
     return this.state.team["members"].map((member, i) => (
       <li key={i} style={{marginBottom: '10px'}}>
+        {member.uid == this.state.team.creator && (
+          <span className="label label-default" style={{marginRight: '5px'}}>Captain</span>
+          )}
         {member.username} (
         <span className="capitalize">
           {member.usertype} - {member.country}) {


### PR DESCRIPTION
Allows team members to leave / be kicked as long as they haven't submitted any flags.

* Users who are kicked or elect to leave a team are placed back on their self-team, bringing along any group memberships they obtained along the way.
* Only team creators can kick other members
* Anyone can leave, team creators can only leave if they are the only remaining member
* The team creator is labeled as the captain in the member list
* If a custom (non-self) team hits 0 members, it is removed

Resolves #432 