### PR TITLE
Add student's email address to parent verification email subject

### DIFF
--- a/picoCTF-web/api/email.py
+++ b/picoCTF-web/api/email.py
@@ -150,8 +150,9 @@ def send_user_verification_email(username):
             competition_url = settings["competition_url"],
             admin_email = settings["admin_email"])
 
-        subject = "{} Parent Account Verification".format(
-            settings["competition_name"])
+        subject = "{} Parent Account Verification for {}".format(
+            settings["competition_name"],
+            user['email'])
         recipients = [user['demo']['parentemail']]
         parent_email = Message(
             body=body, recipients=recipients, subject=subject)


### PR DESCRIPTION
Resolves #436 (It seemed more likely that a parent would recognize their child's email than their username at a glance.)

Should be cherry-pickable into release-2019 / 2019 private