### PR TITLE
Update to import for ProxyFix due to deprecation

### DIFF
--- a/picoCTF-web/api/__init__.py
+++ b/picoCTF-web/api/__init__.py
@@ -5,7 +5,7 @@ import logging
 import traceback
 
 from flask import Flask, jsonify, session
-from werkzeug.contrib.fixers import ProxyFix
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 # these have to come first to avoid circular import issues
 from api.common import check, PicoException, validate  # noqa


### PR DESCRIPTION
Reference: https://werkzeug.palletsprojects.com/en/0.16.x/contrib/fixers/

Deprecated since version 0.15: ProxyFix has moved to
werkzeug.middleware.proxy_fix. All other code in this module is
deprecated and will be removed in version 1.0.

Caused by transitive dependency update of Werkzeug to 1.0.0
