### PR TITLE
Pin werkzeug dependency due to dependency requirements

### DIFF
--- a/picoCTF-web/setup.py
+++ b/picoCTF-web/setup.py
@@ -77,6 +77,7 @@ setup(
         "spur==0.3.21",
         "voluptuous==0.11.7",
         "walrus==0.7.1",
+        "werkzeug<=0.16.1"
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
Should be temporary. Should also consider transition to flask_restx as
flask_restplus is currently unmaintained.

reference:
https://github.com/noirbizarre/flask-restplus/issues/777
https://github.com/python-restx/flask-restx/pull/39
https://github.com/python-restx/flask-restx/issues/34

notice from flask_restplus: https://github.com/noirbizarre/flask-restplus#flask-restplus
"This project has been forked to Flask-RESTX and will be maintained by
by the python-restx organization. Flask-RESTPlus should be considered
unmaintained."