### PR TITLE
Update to web nginx config to prevent visiting restricted pages

### DIFF
--- a/ansible/roles/pico-web/templates/ctf.nginx.j2
+++ b/ansible/roles/pico-web/templates/ctf.nginx.j2
@@ -82,7 +82,7 @@ server {
             proxy_redirect off;
         }
 
-        location ~ ^/(problems|profile|scoreboard|account|shell|faq|contact)$ {
+        location ~ ^/(problems|profile|scoreboard|account|shell|faq|contact)(\.html)?$ {
             auth_request /api/v1/user/authorize/user;
             expires -1;
             default_type text/html;
@@ -94,13 +94,13 @@ server {
             alias {{ pico_http_dir }}/$1.html;
         }
 
-        location ~ ^/(classroom)$ {
+        location ~ ^/(classroom)(\.html)?$ {
             auth_request /api/v1/user/authorize/teacher;
             default_type text/html;
             alias {{ pico_http_dir }}/$1.html;
         }
 
-        location ~ ^/(management)$ {
+        location ~ ^/(management)(\.html)?$ {
             auth_request /api/v1/user/authorize/admin;
             default_type text/html;
             alias {{ pico_http_dir }}/$1.html;


### PR DESCRIPTION
An update to the webserver nginx config to prevent bypassing the `auth_request` function by `.html` to the end of your URL (for example, you can briefly see the management page when unauthenticated by visiting https://2019game.picoctf.com/management.html but cannot if you visit https://2019game.picoctf.com/management ). Currently, there is no immediate security issue with the old config since `redirectIfNotAdmin()` kicks in prior to the API loading the important data, but this could be an issue in the future (and is easy to fix). 