### PR TITLE
Check 'blacklist' when creating users

### DIFF
--- a/picoCTF-web/api/user.py
+++ b/picoCTF-web/api/user.py
@@ -15,15 +15,15 @@ import api
 from api import cache, log_action, PicoException
 
 
-def check_blacklisted_usernames(username):
+def is_blacklisted_username(username):
     """
-    Verify that the username isn't present in the username blacklist.
+    Whether the username is blacklisted.
 
     Args:
         username: the username to check
     """
     settings = api.config.get_settings()
-    return username not in settings.get(
+    return username in settings.get(
         "username_blacklist", api.config.default_settings["username_blacklist"]
     )
 
@@ -182,7 +182,7 @@ def add_user(params, batch_registration=False):
     """
     # Make sure the username is unique
     db = api.db.get_conn()
-    if db.users.find_one(
+    if is_blacklisted_username(params["username"]) or db.users.find_one(
         {"username": params["username"]},
         collation=Collation(locale="en", strength=CollationStrength.PRIMARY),
     ):


### PR DESCRIPTION
**Issue:**
The `picoCTF` web interface has a configuration box for blacklisted
usernames and a function that checks a username against that list.
However, the check function was not called during the user creation
process.  This lack of checking allows registrations with `root`
and `hacksports` to occur.

**Note:**
This bug is not a catastophic vulnerability because the current
configuration of PAM forces local authentication for local users.
It currently results in these users being unable to log into the
shell server because their password is checked against the shadow
file and not the user database.

**Changes:**
- Renames the blacklist check function to make its semantics clear.
- Adds the check to `add_user` and returns the "There is already a
user with this username" message when in the blacklist.  We chose
to reuse this message rather than an explicit blacklist message to
avoid potential leakage of system-level usernames to unregistered
users (registered usernames could log onto shell server and look at
`/etc/passwd`).