### PR TITLE
Close bypass method for email whitelists

### DIFF
--- a/picoCTF-web/api/user.py
+++ b/picoCTF-web/api/user.py
@@ -44,7 +44,7 @@ def verify_email_in_whitelist(email, whitelist=None):
         return True
 
     for email_domain in whitelist:
-        if re.match(r".*?@{}$".format(email_domain), email) is not None:
+        if re.match(r"^[^@]+@{}$".format(email_domain), email) is not None:
             return True
 
     return False


### PR DESCRIPTION
**Issue:**
The regex used for comparing registration emails to a provided
whitelist is vulnerable to a stuffing attack when paired with the
verification email process.  Specifically, an attacker can enter
an email in the form `bad@bad.com;good@good.com` which will pass
a domain check for `good.com` but send the verification email to
`bad@bad.com`.

**Note:**
The modified regex now forces the entire portion after the first
`@` to match the admin provided regex.  This is not strictly RFC
compliant (`@` symbol is allowed in quoted local part), but is
effective and should not cause issues for non-ASCII character sets
either.

**Changes:**
- Modify regex for local part to always terminate at the `@` symbol.