### PR TITLE
Prevent logging of plaintext passwords

### DIFF
--- a/picoCTF-web/api/achievement.py
+++ b/picoCTF-web/api/achievement.py
@@ -111,7 +111,7 @@ def get_processor(aid):
         raise PicoException("Achievement processor is offline.")
 
 
-@log_action
+@log_action()
 def process_achievement(aid, data):
     """
     Determine whether or not an achievement has been earned.

--- a/picoCTF-web/api/group.py
+++ b/picoCTF-web/api/group.py
@@ -88,7 +88,7 @@ def get_member_information(gid):
     return member_information
 
 
-@log_action
+@log_action()
 def create_group(tid, group_name):
     """
     Insert group into the db. Assumes everything is validated.
@@ -154,7 +154,7 @@ def change_group_settings(gid, settings):
     db.groups.update({"gid": group["gid"]}, {"$set": {"settings": settings}})
 
 
-@log_action
+@log_action()
 def join_group(gid, tid, teacher=False):
     """
     Add a team to a group. Assumes everything is valid.
@@ -177,7 +177,7 @@ def join_group(gid, tid, teacher=False):
     cache.invalidate(api.team.get_groups, tid)
 
 
-@log_action
+@log_action()
 def leave_group(gid, tid):
     """
     Remove a team from a group.
@@ -192,7 +192,7 @@ def leave_group(gid, tid):
     cache.invalidate(api.team.get_groups, tid)
 
 
-@log_action
+@log_action()
 def elevate_team(gid, tid):
     """
     Elevate a team within a group.
@@ -207,7 +207,7 @@ def elevate_team(gid, tid):
     cache.invalidate(api.team.get_groups, tid)
 
 
-@log_action
+@log_action()
 def delete_group(gid):
     """
     Delete a group.

--- a/picoCTF-web/api/problem_feedback.py
+++ b/picoCTF-web/api/problem_feedback.py
@@ -57,7 +57,7 @@ def get_problem_feedback(pid=None, tid=None, uid=None, count_only=False):
         return list(db.problem_feedback.find(match, {"_id": 0}))
 
 
-@log_action
+@log_action()
 def upsert_feedback(pid, feedback):
     """
     Add or update problem feedback in the database.

--- a/picoCTF-web/api/submissions.py
+++ b/picoCTF-web/api/submissions.py
@@ -59,7 +59,7 @@ def grade_problem(pid, key, tid=None):
     return (correct, suspicious)
 
 
-@log_action
+@log_action()
 def submit_key(tid, pid, key, method, uid, ip=None):
     """
     User problem submission.

--- a/picoCTF-web/api/team.py
+++ b/picoCTF-web/api/team.py
@@ -444,7 +444,7 @@ def join_team(team_name, password, user):
     return desired_team["tid"]
 
 
-@log_action
+@log_action(dont_log=["params"])
 def update_password_request(params):
     """
     Update team password.
@@ -485,7 +485,7 @@ def is_teacher_team(tid):
         return False
 
 
-@log_action
+@log_action()
 def delete_team(tid):
     """Scrub all traces of a team."""
     db = api.db.get_conn()
@@ -497,7 +497,7 @@ def delete_team(tid):
     api.cache.invalidate(api.team.get_groups, tid)
 
 
-@log_action
+@log_action()
 def remove_member(tid, uid):
     """
     Move the specified member back to their self-team.

--- a/picoCTF-web/api/user.py
+++ b/picoCTF-web/api/user.py
@@ -158,7 +158,7 @@ def _validate_captcha(data):
     return parsed_response["success"] is True
 
 
-@log_action
+@log_action(dont_log=["password"])
 def add_user(params, batch_registration=False):
     """
     Register a new user and creates a team for them automatically.
@@ -344,7 +344,7 @@ def verify_user(uid, token_value):
         return False
 
 
-@log_action
+@log_action(dont_log=["params"])
 def update_password_request(params, uid=None, check_current=False):
     """
     Update account password.
@@ -376,7 +376,7 @@ def update_password_request(params, uid=None, check_current=False):
     )
 
 
-@log_action
+@log_action()
 def disable_account(uid, disable_reason=None):
     """
     Note: The original disable account has now been updated to perform delete account instead.
@@ -497,7 +497,7 @@ def confirm_password(attempt, password_hash):
     return bcrypt.hashpw(attempt.encode("utf-8"), password_hash) == password_hash
 
 
-@log_action
+@log_action(dont_log=["password"])
 def login(username, password):
     """Authenticate a user."""
     user = get_user(name=username, include_pw_hash=True)
@@ -523,7 +523,7 @@ def login(username, password):
         raise PicoException("Incorrect password", 401)
 
 
-@log_action
+@log_action()
 def logout():
     """Clear the session."""
     session.clear()


### PR DESCRIPTION
**Potentially introduces breaking change for analysis tools that
run against the `statistics` collection (none seen in repo).**

**Issue:**
The `statistics` log inadvertently captures plaintext passwords at
several points in the logging process (most noticeably at
registration, login, password reset, and password change).  This
does not follow best practices and defeats the purpose of storing
hashed passwords in the `users` collection.

**Note:**
This creates breaking change in the schema of the `statistics`
collection by removing the `kwargs` field and changing the `args`
field to a dictionary rather than the previous list.  However, the
end result is more useful for debugging (all parameters identified
by name) and removes all occurrences of plaintext passwords stored
in the Mongo database.

**Changes:**
- Modified `log_action` decorator to now take in list of parameters
to ignore when going to log.
- Modified logger (`log_action` and `FunctionLoggingHandler`) to
unify `args` and `kwargs` using the `inspect.getcallargs` function
in Python.  This makes the censoring process significantly easier
and has the added benefit of clearly labeling the parameter list in
the logs.
- Updated all uses of `@log_action` to `@log_action()` or to use
the new `dont_log` functionality (all sites where a plaintext
password is used).