### PR TITLE
update shell folder permissions so can not directory list /html/static

### DIFF
--- a/ansible/roles/pico-shell/tasks/nginx.yml
+++ b/ansible/roles/pico-shell/tasks/nginx.yml
@@ -44,3 +44,11 @@
     mode: 0644
   when: enable_shell_ssl | bool
 
+# create the static folder directory if it does not already exist
+- name: Create static web folder directory if it does not exist
+  file:
+    path: /usr/share/nginx/html/static
+    state: directory
+    mode: 0751
+    owner: root
+    group: root

--- a/ansible/roles/pico-shell/tasks/permissions.yml
+++ b/ansible/roles/pico-shell/tasks/permissions.yml
@@ -51,3 +51,10 @@
     path: /opt/hacksports
     mode: "o-r"
     recurse: yes
+
+# also adding here to update permissions if you have already created this folder.
+- name: Restrict readability of /usr/share/nginx/html/static
+  file:
+    path: /usr/share/nginx/html/static
+    mode: 0751
+    recurse: no


### PR DESCRIPTION
Any participate can currently directory list `/usr/share/nginx/html/static/` and see every static file for every problem (including instances not assigned to them) with `ls -Rla /usr/share/nginx/html/static/` or a similar command.  This update simply removes the ability to directory list `/static/` (similar to how directory listing is removed from `/problems`) simply by changing the permission from **755** to **751**. The update seeks to create the initial `/usr/share/nginx/html/static/` with updated permissions as well as to update the permissions of the file if it is already created. I have not fully tested all features after changing the permissions but it does not impact downloading of static files (i.e. you can still download files that are linked, and I have not found anything else impacted by the change yet other than the ability to do directory listing).

Before:
```
ubuntu@shell:~$ ls -Rla /usr/share/nginx/html/static/
...
/usr/share/nginx/html/static/fa4c53d8d3a20b3e7400a0d735d4fc1f:
total 368
drwxr-xr-x   2 root root   4096 Apr 22 20:12 .
drwxr-xr-x 152 root root  12288 Apr 22 20:35 ..
-rwxr-xr-x   1 root root 359105 Apr 22 20:12 many-options.exe

/usr/share/nginx/html/static/fac065e0d4181145635f5b4aa90e7485:
total 32
drwxr-xr-x   2 root root  4096 Apr 22 20:17 .
drwxr-xr-x 152 root root 12288 Apr 22 20:35 ..
-rwxr-xr-x   1 root root 12896 Apr 22 20:17 ringing-in-my-ears

/usr/share/nginx/html/static/fb513bbb99a9d7db00b2ec49811478d2:
total 32
drwxr-xr-x   2 root root  4096 Apr 22 20:09 .
drwxr-xr-x 152 root root 12288 Apr 22 20:35 ..
-rwxr-xr-x   1 root root 12856 Apr 22 20:09 services

/usr/share/nginx/html/static/fbfe7e740d891c8e501ceba0ae375ba0:
total 17988
drwxr-xr-x   2 root root     4096 Apr 22 20:14 .
drwxr-xr-x 152 root root    12288 Apr 22 20:35 ..
-rw-rw-r--   1 root root 18399924 Apr 22 19:40 stay_out_of_the_water_2.pcapng
```

After:
```
ubuntu@shell:~$ ls -Rla /usr/share/nginx/html/static/
ls: cannot open directory '/usr/share/nginx/html/static/': Permission denied
```