### PR TITLE
Fix vagrant ENV SIP/WIP regression

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,6 +21,12 @@ Vagrant.configure("2") do |config|
     shell.vm.synced_folder ".", "/vagrant", disabled: true
     shell.vm.synced_folder ".", "/picoCTF", owner: "vagrant", group: "vagrant"
 
+    # ensures that SIP/WIP are passed to ansible_local provisioner can use lookup('env',...)
+    shell.vm.provision "shell" do |s|
+      s.path = "./scripts/vagrant-env.sh"
+      s.env  = {SIP: (ENV['SIP'] || '192.168.2.3'), WIP: (ENV['WIP'] || '192.168.2.2')}
+    end
+
     # uses ansible_local so that a user does not need to have ansible installed
     shell.vm.provision :ansible_local do |ansible|
       ansible.install = "yes"
@@ -53,6 +59,12 @@ Vagrant.configure("2") do |config|
 
     web.vm.synced_folder ".", "/vagrant", disabled: true
     web.vm.synced_folder ".", "/picoCTF", owner: "vagrant", group: "vagrant"
+
+    # ensures that SIP/WIP are passed to ansible_local provisioner can use lookup('env',...)
+    web.vm.provision "shell" do |s|
+      s.path = "./scripts/vagrant-env.sh"
+      s.env  = {SIP: (ENV['SIP'] || '192.168.2.3'), WIP: (ENV['WIP'] || '192.168.2.2')}
+    end
 
     # uses ansible_local so that a user does not need to have ansible installed
     web.vm.provision :ansible_local do |ansible|

--- a/infra_local/README.md
+++ b/infra_local/README.md
@@ -123,6 +123,9 @@ and run multiple instances. Start by running a command like the following.
 J=2 M=6 SIP=192.168.2.53 WIP=192.168.2.52 vagrant up shell && SIP=192.168.2.53 WIP=192.168.2.52 vagrant up web
 ```
 
+*Warning*: If you utilize `WIP` or `SIP` you will need to always set those
+environment variables whenever running any `vagrant` or `ansible` commands.
+
 ## Organization
 
 - `ansible.cfg`: points to the relevant roles from both core `picoCTF` as well

--- a/scripts/vagrant-env.sh
+++ b/scripts/vagrant-env.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# This script adds the custom WIP/SIP environment variables to the provided
+# vagrant machines so that they are accessible during provisioning.
+
+# Install to the profile of the ansible_user
+INFILE=/home/vagrant/.profile
+
+# Using sed technique to replace/append a line in file, ref:
+# https://superuser.com/a/976712
+sed -i "/^export SIP=/{h;s/=.*/=${SIP}/};\${x;/^$/{s//export SIP=${SIP}/;H};x}" ${INFILE}
+sed -i "/^export WIP=/{h;s/=.*/=${WIP}/};\${x;/^$/{s//export WIP=${WIP}/;H};x}" ${INFILE}


### PR DESCRIPTION
@carlislemc , fix for #470 

Symptom in the issue was an incorrect configuration causing the example DockerChallenge deployment to fail. In the configuration the docker host is inferred from the shell `ansible_host` setting.

Root cause was that the use of `{{ lookup('env','SIP') or '192.168.2.3' }}` was failing when run with the `ansible_local` provisioner (as used by the Vagrantfile). The lookup is performed on the controller (in this case the vm itself).

This fix adds an additional provisioning script to properly set SIP/WIP in the vms.

Tested a fresh build with the command:
```
J=4 M=8 WIP=192.168.2.52 SIP=192.168.2.53 vagrant up --provision shell && J=2 M=8 WIP=192.168.2.52 SIP=192.168.2.53 vagrant up --provision web
```
As well as a fresh build with just a plain default:
```
vagrant up
```