### PR TITLE
Fix Ansible permissions issue with Windows synced directory

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,7 @@
 # vi: set ft=ruby :
 
 # TODO:
+# - mount_options looks really fishy
 # - use double quote correctly
 
 require 'etc'
@@ -19,7 +20,9 @@ Vagrant.configure("2") do |config|
     shell.vm.network "private_network", ip: (ENV['SIP'] || '192.168.2.3'), nic_type: "virtio"
 
     shell.vm.synced_folder ".", "/vagrant", disabled: true
-    shell.vm.synced_folder ".", "/picoCTF", owner: "vagrant", group: "vagrant"
+    shell.vm.synced_folder ".", "/picoCTF",
+                           owner: "vagrant", group: "vagrant",
+                           mount_options: ["dmode=775", "fmode=775"]
 
     # ensures that SIP/WIP are passed to ansible_local provisioner can use lookup('env',...)
     shell.vm.provision "shell" do |s|
@@ -58,7 +61,9 @@ Vagrant.configure("2") do |config|
     web.vm.network "private_network", ip: (ENV['WIP'] || '192.168.2.2'), nic_type: "virtio"
 
     web.vm.synced_folder ".", "/vagrant", disabled: true
-    web.vm.synced_folder ".", "/picoCTF", owner: "vagrant", group: "vagrant"
+    web.vm.synced_folder ".", "/picoCTF",
+                         owner: "vagrant", group: "vagrant",
+                         mount_options: ["dmode=775", "fmode=775"]
 
     # ensures that SIP/WIP are passed to ansible_local provisioner can use lookup('env',...)
     web.vm.provision "shell" do |s|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,6 @@
 # vi: set ft=ruby :
 
 # TODO:
-# - mount_options looks really fishy
 # - use double quote correctly
 
 require 'etc'
@@ -20,9 +19,13 @@ Vagrant.configure("2") do |config|
     shell.vm.network "private_network", ip: (ENV['SIP'] || '192.168.2.3'), nic_type: "virtio"
 
     shell.vm.synced_folder ".", "/vagrant", disabled: true
-    shell.vm.synced_folder ".", "/picoCTF",
-                           owner: "vagrant", group: "vagrant",
-                           mount_options: ["dmode=775", "fmode=775"]
+    if Vagrant::Util::Platform.windows? then
+        shell.vm.synced_folder ".", "/picoCTF",
+          owner: "vagrant", group: "vagrant",
+          mount_options: ["dmode=775", "fmode=775"]
+    else
+        shell.vm.synced_folder ".", "/picoCTF", owner: "vagrant", group: "vagrant"
+    end
 
     # ensures that SIP/WIP are passed to ansible_local provisioner can use lookup('env',...)
     shell.vm.provision "shell" do |s|
@@ -61,9 +64,13 @@ Vagrant.configure("2") do |config|
     web.vm.network "private_network", ip: (ENV['WIP'] || '192.168.2.2'), nic_type: "virtio"
 
     web.vm.synced_folder ".", "/vagrant", disabled: true
-    web.vm.synced_folder ".", "/picoCTF",
-                         owner: "vagrant", group: "vagrant",
-                         mount_options: ["dmode=775", "fmode=775"]
+    if Vagrant::Util::Platform.windows? then
+        web.vm.synced_folder ".", "/picoCTF",
+          owner: "vagrant", group: "vagrant",
+          mount_options: ["dmode=775", "fmode=775"]
+    else
+        web.vm.synced_folder ".", "/picoCTF", owner: "vagrant", group: "vagrant"
+    end
 
     # ensures that SIP/WIP are passed to ansible_local provisioner can use lookup('env',...)
     web.vm.provision "shell" do |s|


### PR DESCRIPTION
Fixes issue when starting platform via Virtualbox on Windows (without WSL), as otherwise synced folder is given 777 permissions and Ansible refuses to read `infra_local/ansible.cfg`.

```
[WARNING] Ansible is being run in a world writable directory (/picoCTF/infra_local), ignoring it as an ansible.cfg source. For more information see https://docs.ansible.com/ansible/devel/reference_appendices/config.html#cfg-in-world-writable-dir
ERROR! the role 'common' was not found in /picoCTF/infra_local/roles:/home/vagrant/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:/picoCTF/infra_local

The error appears to be in '/picoCTF/infra_local/site.yml': line 12, column 7, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

  roles:
    - {role: common     , tags: ["common"]}
      ^ here
Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.
```