### PR TITLE
Shell login fixes

### DIFF
--- a/ansible/pico-shell/defaults/main.yml
+++ b/ansible/pico-shell/defaults/main.yml
@@ -9,7 +9,7 @@ virtualenv_dir    : "/picoCTF-env"
 ###
 # wetty configuration
 ###
-wetty_js_path     : "/opt/wetty/node_modules/wetty"
+wetty_js_path     : "/opt/wetty/node_modules/wetty/build/main.js"
 
 # configure nginx
 site_config_name  : "shell"

--- a/ansible/pico-shell/files/pam_auth.py
+++ b/ansible/pico-shell/files/pam_auth.py
@@ -6,6 +6,11 @@ import subprocess
 import time
 from os.path import join
 
+# Workaround for https://github.com/picoCTF/picoCTF/issues/478
+# (see https://bugs.launchpad.net/ubuntu/+source/python2.7/+bug/1869115)
+import sys
+sys.path += ["/usr/local/lib/python2.7/dist-packages", "/usr/lib/python2.7/dist-packages"]
+
 import requests
 
 DEFAULT_USER = "nobody"

--- a/ansible/pico-shell/templates/wetty.service.j2
+++ b/ansible/pico-shell/templates/wetty.service.j2
@@ -5,7 +5,7 @@ Description=wetty
 
 [Service]
 Type=simple
-ExecStart=/bin/bash -c '/usr/bin/node {{ wetty_js_path }}/index.js -p {{ wetty_port }} --base /shell/ --sshauth keyboard-interactive'
+ExecStart=/bin/bash -c '/usr/bin/node {{ wetty_js_path }} -p {{ wetty_port }} --base /shell/ --ssh-auth keyboard-interactive'
 User=wetty
 ProtectHome=read-only
 LimitNOFILE=65535


### PR DESCRIPTION
Fixes issues preventing SSH login to the shell server and successful wetty server startup.

- Resolves #478 by adding missing dist-packages directories to libpam-python import path
- Updates wetty.js location and launch flags to match current version
