### PR TITLE
Add flags to control Disk_Size & unattended-up

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,7 +18,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "shell", primary: true do |shell|
     shell.vm.box = "ubuntu/bionic64"
-    shell.vm.disk :disk, size: (ENV['DISK_SIZE'] || "10GB"), primary: true
+    shell.vm.disk :disk, size: (ENV['SHELL_DISK_SIZE'] || "10GB"), primary: true
     shell.vm.network "private_network", ip: (ENV['SIP'] || '192.168.2.3'), nic_type: "virtio"
     shell.vm.network "forwarded_port", guest: 2376, host: 2223, auto_correct: true
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,8 @@
 
 require 'etc'
 
+ENV['VAGRANT_EXPERIMENTAL'] = "disks"
+
 # Extract suffix if working directory starts with prefix; otherwise return "".
 def compute_auto_name_suffix(prefix = "picoCTF")
   dirname = File.basename(Dir.getwd)
@@ -16,6 +18,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "shell", primary: true do |shell|
     shell.vm.box = "ubuntu/bionic64"
+    shell.vm.disk :disk, size: (ENV['DISK_SIZE'] || "10GB"), primary: true
     shell.vm.network "private_network", ip: (ENV['SIP'] || '192.168.2.3'), nic_type: "virtio"
     shell.vm.network "forwarded_port", guest: 2376, host: 2223, auto_correct: true
 

--- a/ansible/common/tasks/utils.yml
+++ b/ansible/common/tasks/utils.yml
@@ -20,3 +20,10 @@
         ]
   environment:
     DEBIAN_FRONTEND: noninteractive
+
+- name: Disable unattended upgrades
+  apt:
+    state: absent
+    name: unattended-upgrades
+    purge: True
+  when: disable_unattended_upgrades | default(false) | bool

--- a/infra_local/README.md
+++ b/infra_local/README.md
@@ -122,7 +122,7 @@ and run multiple instances. Start by running a command like the following.
 - `SHELL_DISK_SIZE` specifies the size for the `/` partition for the shell server. Defaults to 10GB
 
 ```
-J=2 M=6 SIP=192.168.2.53 WIP=192.168.2.52 DISK_SIZE=20GB vagrant up shell && SIP=192.168.2.53 WIP=192.168.2.52 vagrant up web
+J=2 M=6 SIP=192.168.2.53 WIP=192.168.2.52 SHELL_DISK_SIZE=20GB vagrant up shell && SIP=192.168.2.53 WIP=192.168.2.52 vagrant up web
 ```
 
 *Warning*: If you utilize `WIP` or `SIP` you will need to always set those

--- a/infra_local/README.md
+++ b/infra_local/README.md
@@ -112,16 +112,17 @@ ansible -become -a 'shell_manager status' shell
 
 ### Modifying the local infrastructure virtual machines
 
-There are now quick ways to change the memory, number of CPUs and IP addresses
+There are now quick ways to change the storage, memory, number of CPUs and IP addresses
 and run multiple instances. Start by running a command like the following.
 
 - `J` is the number of CPUs
 - `M` is the amount of memory in GB
 - `SIP` is shell IP address (default is 192.168.2.2)
 - `WIP` is web IP address (default is 192.68.2.3)
+- `SHELL_DISK_SIZE` specifies the size for the `/` partition for the shell server. Defaults to 10GB
 
 ```
-J=2 M=6 SIP=192.168.2.53 WIP=192.168.2.52 vagrant up shell && SIP=192.168.2.53 WIP=192.168.2.52 vagrant up web
+J=2 M=6 SIP=192.168.2.53 WIP=192.168.2.52 DISK_SIZE=20GB vagrant up shell && SIP=192.168.2.53 WIP=192.168.2.52 vagrant up web
 ```
 
 *Warning*: If you utilize `WIP` or `SIP` you will need to always set those

--- a/infra_local/inventory.yml
+++ b/infra_local/inventory.yml
@@ -20,6 +20,8 @@ all:
   vars:
       # SSH admin keys (Optional)
       admin_keys                  : []
+      # Disable Unattended Upgrades
+      disable_unattended_upgrades : False
 
       # Web automation and Features (Optional)
       auto_add_web_admin          : True

--- a/infra_remote/inventory.yml
+++ b/infra_remote/inventory.yml
@@ -47,6 +47,8 @@ all:
 
       # SSH admin keys (Optional)
       admin_keys : []
+      # Disable Unattended Upgrades
+      disable_unattended_upgrades : False
 
       ## Web automation and Features (Optional):
       # These are currently setup to fully configure and start an event. This


### PR DESCRIPTION
## Introduction
### Issues:
During internal use of PICO for teaching purposes, two
issues often popped up:
1. Something kept breaking down (auth for example), due to
background updates
2. Students often used vs-code servers, which in a class of 90,
ate up the 10GB default disk space

### proposed Fixes:
These changes implement:
- "SHELL_DISK_SIZE": An environment variable with value of the form
`XGB` with X being a numberic value, to control max disk size.
- "disable-unattended-upgrades": A Flag in the anisble config to
uninstall `unattended-upgrades`, preventing unwanted updates on
private deployments.

## Testing
I tested the deployment on Windows 10 deployment, backed with VirtualBox.

#### A. DISK_SIZE
In order to try out the disk resize utility, Try
1. `bash`: `SHELL_DISK_SIZE=20GB vagrant up`
2. `powershell`:  `$env:SHELL_DISK_SIZE = "20GB"; vagrant up`

The expected behaviour should be different disk size for the `SHELL` VM:
```bash
vagrant ssh shell
>> df -h
```
Result:
```
vagrant@picoCTF-shell-dev:~$ df -h
Filesystem      Size  Used Avail Use% Mounted on
udev            985M     0  985M   0% /dev
tmpfs           200M  724K  199M   1% /run
/dev/sda1   19.4G  5.5G   13.9G  71% /
tmpfs           997M     0  997M   0% /dev/shm
tmpfs           5.0M     0  5.0M   0% /run/lock
tmpfs           997M     0  997M   0% /sys/fs/cgroup
tmpfs           200M     0  200M   0% /run/user/1000
picoCTF         238G  102G  137G  43% /picoCTF
```

#### B. unattended upgrades
The second change disables unattended upgrades. This feature is a bit more work to activate. (**False Default**)
Change `infra_local/inventory.yml` (see diff) to `True`. This should uninstall the unattended-upgrades.

Command:
`sudo apt-get remove unattended-upgrades`

In the result we see it's uninstalled.
```bash
vagrant@picoCTF-shell-dev:~$ sudo apt-get remove unattended-upgrades
/usr/lib/python2.7/dist-packages/OpenSSL/crypto.py:12: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.
  from cryptography import x509
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Package 'unattended-upgrades' is not installed, so not removed
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
```