### PR TITLE
Hotfix: Ansible install, python2 depricated

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,6 +41,7 @@ Vagrant.configure("2") do |config|
     shell.vm.provision "ansible_local" do |ansible|
       ansible.install = "yes"
       ansible.install_mode = "pip"
+      ansible.pip_install_cmd = "curl https://bootstrap.pypa.io/2.7/get-pip.py | sudo python"
       ansible.version = "2.9.11"
       ansible.compatibility_mode = "2.0"
       ansible.playbook = "site.yml"
@@ -87,6 +88,7 @@ Vagrant.configure("2") do |config|
     web.vm.provision "ansible_local" do |ansible|
       ansible.install = "yes"
       ansible.install_mode = "pip"
+      ansible.pip_install_cmd = "curl https://bootstrap.pypa.io/2.7/get-pip.py | sudo python"
       ansible.version = "2.9.11"
       ansible.compatibility_mode = "2.0"
       ansible.playbook = "site.yml"


### PR DESCRIPTION
As of 23rd January, 2021, pip v21.0 depricated python2
and removed support for python2. As of now, ansible seems to use
python2 for deployment.
https://github.com/pypa/pip/issues/6148

This broke the installation. For hotfix, added custom pip install
command based on Vagrant's ansible local documentation
https://www.vagrantup.com/docs/provisioning/ansible_local

## testing
```bash
vagrant up
```

Note: Requires fairly recent version of vagrant