### PR TITLE
Update get_problem_solvs db query

### DIFF
--- a/picoCTF-web/api/stats.py
+++ b/picoCTF-web/api/stats.py
@@ -307,7 +307,7 @@ def get_problem_solves(pid):
     """
     db = api.db.get_conn()
 
-    return db.submissions.count({"pid": pid, "correct": True})
+    return db.submissions.count({"pid": pid, "correct": true})
 
 
 # Stored by the cache_stats daemon


### PR DESCRIPTION
Was recently adding variable scoring that used get_problem_solves. It was returning 0, found by running the query directly on mongo correct:True had to be set to correct: true to get correct results.