### PR TITLE
Force idna package version

### DIFF
--- a/picoCTF-shell/setup.py
+++ b/picoCTF-shell/setup.py
@@ -65,6 +65,7 @@ setup(
         "coloredlogs==10.0",
         "docker[tls]==4.2.0",
         "Flask==1.1.1",
+        "idna<3",
         "Jinja2==2.10.1",
         "openssh-wrapper==0.4",
         "psutil==5.6.6",


### PR DESCRIPTION
`idna` recently released version 3.  This causes a version conflict in the `picoCTF-shell` during install because `urllib3` is installed before `requests`.  `urllib3` does not specify an upper bound on `idna`'s version, but `requests` does (`idna<3`).  Since `idna 3.1` is already installed by the time pip attempts to resolve `requests`, the process fails.